### PR TITLE
Add vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-node_modules/
-bower_components/
+node_modules
+bower_components
 .sass-cache/
 .tmp/
 dist/
 src/app/config.local.json
 src/app/config.js
+Vagrantfile
+.vagrant/

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -1,0 +1,64 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "flavio/opensuse13-2"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", guest: 8188, host: 8188
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/home/vagrant/jangouts"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: false, path: "provisioning/setup.sh"
+end

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -25,6 +25,7 @@ Vagrant.configure(2) do |config|
   # config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.network "forwarded_port", guest: 3000, host: 3000
   config.vm.network "forwarded_port", guest: 8188, host: 8188
+  config.vm.network "forwarded_port", guest: 8989, host: 8989
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -38,7 +38,7 @@ module.exports = function(options) {
     fs.exists(components_symlink, function (exists) {
       if (!exists) {
         gutil.log("Symlinking " + components_symlink + " -> bower_components");
-        fs.symlinkSync('../../../bower_components', components_symlink);
+        fs.symlinkSync('../../bower_components', components_symlink);
       }
     });
   });

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This is a quick and dirty script to setup an openSUSE based development
+# environment form Jangouts and it's intended to be used by Vagrant when
+# setting up the machine.
+
+set -x
+
+#
+# Installing Janus Gateway. This will take a while..."
+#
+sudo zypper ar -f --no-gpgcheck -r http://download.opensuse.org/repositories/home:/mlin7442:/hackweek11/openSUSE_13.2/home:mlin7442:hackweek11.repo
+# FIXME: we need this because of a conflict with libnice.
+sudo zypper -q -n remove patterns-openSUSE-minimal_base-conflicts
+sudo zypper -q -n in janus-gateway
+
+#
+# Generating self-signed certificate for Janus Gateway
+#
+if [ ! -f /usr/share/janus/certs/mycert.pem ]
+then
+  sudo openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /usr/share/janus/certs/mycert.key \
+    -out /usr/share/janus/certs/mycert.pem -subj "/C=DE/ST=/L=/O=/CN=jangouts.local"
+fi
+
+#
+# Starting Janus service
+#
+sudo systemctl start janus.service
+sudo systemctl enable janus.service
+
+#
+# Installing Janguts requirements
+#
+sudo zypper -q -n in git
+# FIXME: in the future, packages for openSUSE should be used.
+if [ ! -d /home/vagrant/.nvm ]
+then
+  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+  source ~/.nvm/nvm.sh
+  nvm install stable
+  nvm alias default stable
+  npm install -g bower gulp
+fi
+
+#
+# Install NPM and Bower packages.
+#
+[[ ! -d node_modules ]] && mkdir node_modules
+cd /home/vagrant/jangouts
+[[ ! -L node_modules ]] && ln -s ../node_modules
+npm install && bower install

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -10,8 +10,8 @@ set -x
 #
 sudo zypper ar -f --no-gpgcheck -r http://download.opensuse.org/repositories/home:/mlin7442:/hackweek11/openSUSE_13.2/home:mlin7442:hackweek11.repo
 # FIXME: we need this because of a conflict with libnice.
-sudo zypper -q -n remove patterns-openSUSE-minimal_base-conflicts
-sudo zypper -q -n in janus-gateway
+sudo zypper -n remove patterns-openSUSE-minimal_base-conflicts
+sudo zypper -n in janus-gateway
 
 #
 # Generating self-signed certificate for Janus Gateway
@@ -32,7 +32,7 @@ sudo systemctl enable janus.service
 #
 # Installing Janguts requirements
 #
-sudo zypper -q -n in git
+sudo zypper -n in git
 # FIXME: in the future, packages for openSUSE should be used.
 if [ ! -d /home/vagrant/.nvm ]
 then

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -31,17 +31,32 @@
     this.room = null;
     this.janus = null;
 
-    var wsProtocol = (window.location.protocol === "https:") ? "wss:" : "ws:";
     if (jhConfig.janusServer) {
       this.server = jhConfig.janusServer;
     } else {
-      this.server = [
-        wsProtocol + '//' + window.location.hostname + '/janus/',
-        window.location.protocol + '//' + window.location.hostname + '/janus/'
-      ];
+      this.server = defaultJanusServer();
     }
+
     if (jhConfig.janusServerSSL && (window.location.protocol === "https:")) {
       this.server = jhConfig.janusServerSSL;
+    }
+
+    function defaultJanusServer() {
+      var wsProtocol;
+      var wsPort;
+
+      if (window.location.protocol === "https:") {
+        wsProtocol = "wss:";
+        wsPort = "8989";
+      } else {
+        wsProtocol = "ws:";
+        wsPort = "8188"
+      }
+
+      return [
+        wsProtocol + '//' + window.location.hostname + ':' + wsPort + '/janus/',
+        window.location.protocol + '//' + window.location.hostname + '/janus/'
+      ];
     }
 
     function connect() {


### PR DESCRIPTION
A Vagrantfile is provided to set up a development environment. It uses a 'quick and dirty' script that will be converted in something cleaner in a near future.

Just rename `Vagrantfile.sample` to `Vagrantfile` and type `vagrant up`. It could take a while so, please, be patient.