### PR TITLE
Fix loading templates for angular-extended-notification

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -49,7 +49,7 @@ angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch',
   })
   .config(function(notificationsProvider) {
     notificationsProvider.setDefaults({
-      templatesDir: 'bower_components/angular-extended-notifications/templates/',
+      templatesDir: 'app/templates/',
       faIcons: true,
       closeOnRouteChange: 'route'
     });

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -51,7 +51,7 @@ angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch',
     notificationsProvider.setDefaults({
       templatesDir: 'app/templates/',
       faIcons: true,
-      closeOnRouteChange: 'route'
+      closeOnRouteChange: 'state'
     });
   })
   .config(['localStorageServiceProvider', function (localStorageServiceProvider) {

--- a/src/app/templates/global-notification.html
+++ b/src/app/templates/global-notification.html
@@ -1,0 +1,22 @@
+<style>
+  #global-notifications{position:fixed;z-index:1030;top:51px;left:0;text-align:center;background-color:#cfe1e9;color:#212121;width:100%;}
+  .global-notification{padding: 4px 10px;}
+  .global-notification .icon{margin-right:5px !important}
+  .global-notification .close-button{color:#777;margin-left:10px !important;cursor:pointer}
+  .global-notification .close-button:hover{color:#3b3b3b}
+  .global-notification.notification-warning{background-color:#ffe479}
+  .global-notification.notification-info{background-color:#9dd3eb}
+  .global-notification.notification-success{background-color:#C5ED73}
+  .global-notification.notification-error{background-color:#d9534f;color:#fff;}
+  .global-notification.notification-error .close-button{color:#fff}
+  .global-notification.notification-error .close-button:hover{color:#ff9898}
+</style>
+
+<div class="global-notification notification-{{data.type}}">
+  <i ng-class="data.faIcon" ng-if="data.faIcon" class="fa fa-fw icon"></i>
+  <strong ng-if="data.title">{{data.title}}:&nbsp;</strong><span ng-click="close()" ng-if="data.closeButton" class="close-button pull-right">✖</span>
+  <span>{{data.message}}</span>
+  <a ng-repeat="action in data.actions" ng-click="action.fn()" ng-class="action.className">
+    {{action.label}} 
+  </a>
+</div>

--- a/src/app/templates/gmail-notification.html
+++ b/src/app/templates/gmail-notification.html
@@ -1,0 +1,57 @@
+<div class="gmail-template">
+  <style scoped>
+    .gmail-template {
+      position: relative;
+      right: 0;
+      left: 0;
+      margin: 4px 0;
+      text-align: center;
+    }
+    .gmail-template div {
+      position: relative;
+      display: inline-block;
+      margin: 0 auto;
+
+      border:1px solid rgb(240, 195, 109);
+      background-color: rgb(249, 237, 190);
+      font-size: 13px;
+      font-weight: bold;
+      padding:2px 8px 2px 8px;
+
+      -webkit-transition: opacity 0.5s ease-out 4s;
+      -moz-transition: opacity 0.5s ease-out 4s;
+      -o-transition: opacity 0.5s ease-out 4s;
+      transition: opacity 0.5s ease-out 4s;
+    }
+    .gmail-template .gmail-template-error {
+      background-color: #DD8181;
+      border: 1px solid #D54B4B;
+    }
+    .gmail-template-close {
+      color: #9E9E9E;
+    }
+    .gmail-template-close:hover {
+      color: #505050;
+    }
+    .gmail-template-error .gmail-template-close {
+      color: #777777;
+    }
+    .gmail-template-error .gmail-template-close:hover {
+      color: #3B3B3B;
+    }
+    .gmail-template a {
+      cursor: pointer;
+      text-decoration: underline;
+    }
+  </style>
+
+  <div ng-class="'gmail-template-' + data.type">
+    <i class="fa fa-fw" ng-class="data.faIcon" ng-if="data.faIcon"></i>
+    {{data.title}}: {{data.message}}
+    <a ng-repeat="action in data.actions" ng-click="action.fn()" ng-class="action.className">
+      {{action.label}} 
+    </a>
+    <i class="fa fa-fw fa-times gmail-template-close" ng-click="close()" ng-if="data.faIcon && data.closeButton"></i>
+    <span class="gmail-template-close" ng-click="close()" ng-if="!data.faIcon && data.closeButton">✖</span>
+  </div>
+</div>


### PR DESCRIPTION
This should fix #93. Copying the templates is surely not the best way but, as angular-extended-notification seems to be not actively developed anymore, it just enough for us.