### PR TITLE
Replace "Video thumbnails" checkbox with a button only in the topbar (not at the signing form)

### DIFF
--- a/src/app/components/user/jh-signin-form.html
+++ b/src/app/components/user/jh-signin-form.html
@@ -27,7 +27,7 @@
         <option value="" disabled selected>Select a room</option>
       </select>
     </div>
-    <jh-thumbnails-mode-button></jh-thumbnails-mode-button>
+    <jh-thumbnails-mode-button text-template="true"></jh-thumbnails-mode-button>
     <button id="signInButton" class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
   </form>
   <div class="login-msg">

--- a/src/app/components/videochat/jh-thumbnails-mode-button.directive.js
+++ b/src/app/components/videochat/jh-thumbnails-mode-button.directive.js
@@ -16,7 +16,9 @@
   function jhThumbnailsModeButtonDirective(jhConfig, $timeout) {
     return {
       restrict: 'EA',
-      templateUrl: 'app/components/videochat/jh-thumbnails-mode-button.html',
+      templateUrl: function(elem, attrs) {
+        return attrs.textTemplate ? 'app/components/videochat/jh-thumbnails-mode-button-with-text.html' : 'app/components/videochat/jh-thumbnails-mode-button.html'
+      },
       scope: {},
       controllerAs: 'vm',
       bindToController: true,

--- a/src/app/components/videochat/jh-thumbnails-mode-button.html
+++ b/src/app/components/videochat/jh-thumbnails-mode-button.html
@@ -1,11 +1,10 @@
-<div
-  class="checkbox"
-  tooltip="Disable to lower bandwidth and CPU usage"
-  tooltip-placement="bottom">
-  <label>
-    <input
-      type="checkbox"
-      ng-checked="vm.isChecked()"
-      ng-click="vm.click()">Video thumbnails</input>
-  </label>
-</div>
+<button
+   ng-class="{ 'btn-danger': !vm.isChecked() }"
+   class="btn"
+   ng-click="vm.click()"
+   title="Toggle Picture/Video thumbnails.
+Use picture mode to lower bandwidth and CPU usage">
+  <span class="glyphicon"
+    ng-class="{ 'glyphicon-picture': !vm.isChecked(), 'glyphicon-facetime-video': vm.isChecked() }"
+    aria-hidden="true"></span>
+</button>


### PR DESCRIPTION
This is how it was before:
![video_thumbnails_with_text](https://cloud.githubusercontent.com/assets/11314634/11718404/13abedda-9f56-11e5-8d6e-00972e7ecac0.png)

Now with the button unchecked:
![video_thumbnails_with_button_unchecked](https://cloud.githubusercontent.com/assets/11314634/11718427/2817305e-9f56-11e5-84be-db0f5e5259a7.png)

With the button checked:
![video_thumbnails_with_button_checked](https://cloud.githubusercontent.com/assets/11314634/11718436/36335582-9f56-11e5-9868-aadeda0645d2.png)

And the tooltip changed:
![video_thumbnails_with_button_tooltip](https://cloud.githubusercontent.com/assets/11314634/11718439/3f7b3b0a-9f56-11e5-89f4-89ec113637dc.png)
