### PR TITLE
Fix off-by-one error in startMuted

### DIFF
--- a/src/app/components/notifier/mute-notifier.service.js
+++ b/src/app/components/notifier/mute-notifier.service.js
@@ -33,10 +33,10 @@
 
     function joinedMuted(){
       var notiftext = "You joined muted because ";
-      if(jhConfig.joinUnmutedLimit == 0){
+      if(jhConfig.joinUnmutedLimit === 0){
         notiftext += "everyone who joins is muted by default.";
       }
-      else if(jhConfig.joinUnmutedLimit == 1){
+      else if(jhConfig.joinUnmutedLimit === 1){
         notiftext +=  "there is more than one participant.";
       }
       else{

--- a/src/app/components/notifier/mute-notifier.service.js
+++ b/src/app/components/notifier/mute-notifier.service.js
@@ -32,15 +32,15 @@
     }
 
     function joinedMuted(){
-      var notiftext = "You joined muted because ";
+      var notiftext = "You are muted because ";
       if(jhConfig.joinUnmutedLimit === 0){
-        notiftext += "everyone who joins is muted by default.";
+        notiftext += "everyone who enters a room is muted by default.";
       }
       else if(jhConfig.joinUnmutedLimit === 1){
-        notiftext +=  "there is more than one participant.";
+        notiftext +=  "there is already one participant in the room.";
       }
       else{
-        notiftext += "there are more than " + jhConfig.joinUnmutedLimit + " participants.";
+        notiftext += "there are already " + jhConfig.joinUnmutedLimit + " participants in the room.";
       }
 
       info(notiftext);
@@ -69,7 +69,7 @@
           fn: function() { ActionService.toggleChannel("audio"); notif.close(); }
         },
         {
-          label: 'Do not show again',
+          label: "Don't show again",
           className: 'btn btn-default',
           fn: function() { noShow[text] = true; notif.close(); }
         }]

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -153,7 +153,7 @@
             // Step 4a (parallel with 4b). Publish our feed on server
 
             if (jhConfig.joinUnmutedLimit !== undefined && jhConfig.joinUnmutedLimit !== null) {
-              startMuted = (msg.publishers instanceof Array) && msg.publishers.length > jhConfig.joinUnmutedLimit;
+              startMuted = (msg.publishers instanceof Array) && msg.publishers.length >= jhConfig.joinUnmutedLimit;
             }
 
             connection.publish({


### PR DESCRIPTION
This fix a off-by-one error in the feature recently implemented by @sandr3j in #125. The start muted feature was actually activated one participant later than expected. For example, a value of 0 for `joinUnmutedLimit`shows the message "everybody start muted", but actually only the second (and upcoming) participants started muted.