### PR TITLE
Allow name change. This closes #15.

### DIFF
--- a/src/app/components/feed/feeds.factory.js
+++ b/src/app/components/feed/feeds.factory.js
@@ -293,6 +293,30 @@
       };
 
       /**
+       * notifying changes to the remote peers.
+       */
+      this.updateDisplay = function() {
+        var that = this;
+        $timeout(function() {
+          DataChannelService.sendStatus(that);
+        });
+      };
+
+      /**
+       * Sets display attribute for this feed. Works only for remote ones.
+       */
+      this.setDisplay = function(val) {
+        this.display = val;
+      }; 
+
+      /**
+       * Gets the display value for this feed
+       */
+      this.getDisplay = function() {
+        return this.display;
+      };
+
+      /**
        * Reads the representation of the local feed in order to send it to the
        * remote peers.
        *
@@ -304,7 +328,7 @@
         options = options || {};
         if (!options.exclude) { options.exclude = []; }
 
-        var attrs = ["audioEnabled", "videoEnabled", "speaking", "picture"];
+        var attrs = ["audioEnabled", "videoEnabled", "speaking", "picture", "display"];
         var status = {};
 
         _.forEach(attrs, function(attr) {

--- a/src/app/components/feed/jh-feed.directive.js
+++ b/src/app/components/feed/jh-feed.directive.js
@@ -11,7 +11,7 @@
   angular.module('janusHangouts')
     .directive('jhFeed', jhFeed);
 
-  jhFeed.$inject = ['RoomService', '$interval', 'jhConfig', 'MuteNotifier'];
+  jhFeed.$inject = ['RoomService', '$interval', 'jhConfig', 'MuteNotifier', '$state'];
 
   function jhFeed(RoomService, $interval, jhConfig, MuteNotifier) {
     return {
@@ -92,13 +92,16 @@
       }
     }
 
-    function JhFeedCtrl() {
+    function JhFeedCtrl($state) {
       /* jshint: validthis */
       var vm = this;
       vm.mirrored = (vm.feed.isPublisher && !vm.feed.isLocalScreen);
       vm.thumbnailTag = thumbnailTag;
       vm.initPics = initPics;
       vm.takePic = takePic;
+      vm.updateName = updateName;
+      vm.nameIsEditable = false;
+      vm.isEditable = isEditable;
 
       function thumbnailTag() {
         if (vm.highlighted || vm.feed.isIgnored) { return "placeholder"; }
@@ -114,6 +117,20 @@
             return "placeholder";
           }
         }
+      }
+
+      function isEditable(){
+        if(vm.feed.isPublisher) {
+          vm.nameIsEditable = true;
+        }
+      }
+
+      function updateName() {
+        if(vm.feed.isPublisher) {
+          vm.feed.updateDisplay();
+        }
+        vm.nameIsEditable = false;
+        $state.go('room', {user: vm.feed.display}, {notify: false});
       }
 
       function initPics(element) {

--- a/src/app/components/feed/jh-feed.html
+++ b/src/app/components/feed/jh-feed.html
@@ -39,7 +39,11 @@
     </div>
   </div>
   <figcaption>
-    <span class="caption">{{ vm.feed.display }}</span>
+    <span class="caption" ng-dblclick="vm.isEditable()" ng-hide="vm.nameIsEditable">{{vm.feed.display}}</span>
+    <div class="caption" ng-show="vm.nameIsEditable" >
+      <input type="text" class="edit-textbox" ng-model="vm.feed.display">
+      <button class="btn btn-xs btn-danger edit-button" ng-click="vm.updateName()">OK</button>
+    </div>
     <div class="buttons">
       <jh-unpublish-button feed="vm.feed"></jh-unpublish-button>
       <jh-audio-button feed="vm.feed"></jh-audio-button>

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -75,7 +75,18 @@ body {
         overflow: hidden;
         position: absolute;
         width: 80%;
-        height: 20px;
+        height: 21px;
+        display: flex;
+        flex-wrap: wrap;      
+        .edit-textbox {
+          width: 60%;
+          color: black;
+          height: 21px;
+          order: 1;
+        }
+        .edit-button {
+          order: 2;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes [#15](https://github.com/jangouts/jangouts/issues/15)
Allows name change of the publisher's feed and the change is reflected in peers feed also.
When publisher double clicks the name in his feed it becomes editable.

Bonus Track : Also the change is reflected in the url. 
Did not add for animation of the feed while changing name (Extra bonus track).