### PR TITLE
Unpublish shared window/screen feed when stop sharing

### DIFF
--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -369,6 +369,12 @@
           console.log(" ::: Got the screen stream :::");
           var feed = FeedsService.find(id);
           feed.setStream(stream);
+
+          // Unpublish feed when screen sharing stops
+          stream.onended = function () {
+            unPublishFeed(id);
+          };
+
         },
         onmessage: function(msg, jsep) {
           console.log(" ::: Got a message (screen) :::");

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -373,6 +373,7 @@
           // Unpublish feed when screen sharing stops
           stream.onended = function () {
             unPublishFeed(id);
+            ScreenShareService.setInProgress(false);
           };
 
         },


### PR DESCRIPTION
This solution uses MediaStream onended callback which is [not implemented in Firefox yet](https://bugzilla.mozilla.org/show_bug.cgi?id=1045810).

Tested with Chromium.

Closes #25