### PR TITLE
Vagrant uses openSUSE Leap 42.1 instead of 13.2

### DIFF
--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "flavio/opensuse13-2"
+  config.vm.box = "opensuse/openSUSE-42.1-x86_64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -8,20 +8,18 @@ set -x
 #
 # Installing Janus Gateway. This will take a while..."
 #
-sudo zypper ar -f --no-gpgcheck -r http://download.opensuse.org/repositories/home:/mlin7442:/hackweek11/openSUSE_13.2/home:mlin7442:hackweek11.repo
+sudo zypper ar -f --no-gpgcheck -r http://download.opensuse.org/repositories/network:/jangouts/openSUSE_Leap_42.1/network:jangouts.repo
 # FIXME: we need this because of a conflict with libnice.
-sudo zypper -n remove patterns-openSUSE-minimal_base-conflicts
-sudo zypper -n in -t pattern devel_C_C++
 sudo zypper -n in janus-gateway
 
 #
 # Generating self-signed certificate for Janus Gateway
 #
-if [ ! -f /usr/share/janus/certs/mycert.pem ]
+if [ ! -f /etc/janus/cert.pem ]
 then
   sudo openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
-    -keyout /usr/share/janus/certs/mycert.key \
-    -out /usr/share/janus/certs/mycert.pem -subj "/C=DE/ST=/L=/O=/CN=jangouts.local"
+    -keyout /etc/janus/cert.key -out /etc/janus/cert.pem \
+    -subj "/C=DE/ST=/L=/O=/CN=jangouts.local"
 fi
 
 #
@@ -31,18 +29,10 @@ sudo systemctl start janus.service
 sudo systemctl enable janus.service
 
 #
-# Installing Janguts requirements
+# Installing Jangouts development requirements
 #
-sudo zypper -n in git
-# FIXME: in the future, packages for openSUSE should be used.
-if [ ! -d /home/vagrant/.nvm ]
-then
-  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.26.1/install.sh | bash
-  source ~/.nvm/nvm.sh
-  nvm install 0.12
-  nvm alias default 0.12
-  npm install -g bower gulp
-fi
+sudo zypper -n in git nodejs npm
+sudo npm install -g bower gulp
 
 #
 # Install NPM and Bower packages.


### PR DESCRIPTION
Vagrant will use a openSUSE Leap 42.1 box.