### PR TITLE
Fix #172: use ng-src instead of src

### DIFF
--- a/src/app/components/feed/jh-feed.html
+++ b/src/app/components/feed/jh-feed.html
@@ -8,7 +8,7 @@
       ng-show="vm.thumbnailTag() === 'video'">
     </video>
     <img
-      src="{{vm.feed.getPicture()}}"
+      ng-src="{{vm.feed.getPicture()}}"
       class="face"
       ng-class="{mirrored: vm.mirrored}"
       ng-show="vm.thumbnailTag() === 'picture'">


### PR DESCRIPTION
AngularJS doesn't parse markup in src attributes, which results in its
literal contents being used as the URL instead.