### PR TITLE
Fix "Has left the room" message displayed twice

### DIFF
--- a/src/app/components/room/action.service.js
+++ b/src/app/components/room/action.service.js
@@ -82,17 +82,19 @@
     }
 
     function destroyFeedLeaving(feedId) {
-      destroyfeed(feedID)
+      var feed = FeedsService.find(feedId);
+      destroyFeed(feedId);
       // Log the event
       var entry = new LogEntry("destroyFeedLeaving", {feed: feed});
       LogService.add(entry);
     }
 
     function destroyFeedUnpublish(feedId) {
-      destroyfeed(feedID)
+      var feed = FeedsService.find(feedId);
+      destroyFeed(feedId);
       // Log the event
       var entry = new LogEntry("destroyFeedUnpublish", {feed: feed});
-      if (entry.text !="") {
+      if (entry.text !== "") {
         LogService.add(entry);
       }
     }

--- a/src/app/components/room/action.service.js
+++ b/src/app/components/room/action.service.js
@@ -92,7 +92,9 @@
       destroyfeed(feedID)
       // Log the event
       var entry = new LogEntry("destroyFeedUnpublish", {feed: feed});
-      LogService.add(entry);
+      if (entry.text !="") {
+        LogService.add(entry);
+      }
     }
 
     function ignoreFeed(feedId) {

--- a/src/app/components/room/action.service.js
+++ b/src/app/components/room/action.service.js
@@ -18,7 +18,8 @@
     this.enterRoom = enterRoom;
     this.leaveRoom = leaveRoom;
     this.remoteJoin = remoteJoin;
-    this.destroyFeed = destroyFeed;
+    this.destroyFeedLeaving = destroyFeedLeaving;
+    this.destroyFeedUnpublish = destroyFeedUnpublish;
     this.ignoreFeed = ignoreFeed;
     this.stopIgnoringFeed = stopIgnoringFeed;
     this.writeChatMessage = writeChatMessage;
@@ -40,7 +41,7 @@
       var that = this;
 
       _.forEach(FeedsService.allFeeds(), function(feed) {
-        that.destroyFeed(feed.id);
+        that.destroyFeedLeaving(feed.id);
       });
     }
 
@@ -78,8 +79,19 @@
         feed.disconnect();
         FeedsService.destroy(feedId);
       });
+    }
+
+    function destroyFeedLeaving(feedId) {
+      destroyfeed(feedID)
       // Log the event
-      var entry = new LogEntry("destroyFeed", {feed: feed});
+      var entry = new LogEntry("destroyFeedLeaving", {feed: feed});
+      LogService.add(entry);
+    }
+
+    function destroyFeedUnpublish(feedId) {
+      destroyfeed(feedID)
+      // Log the event
+      var entry = new LogEntry("destroyFeedUnpublish", {feed: feed});
       LogService.add(entry);
     }
 

--- a/src/app/components/room/log-entries.factory.js
+++ b/src/app/components/room/log-entries.factory.js
@@ -45,11 +45,16 @@
         return "Screen sharing started";
       };
 
-      this.destroyFeedText = function() {
+      this.destroyFeedLeavingText = function() {
+        return this.content.feed.display + " has left the room";
+      };
+
+      this.destroyFeedUnpublishText = function() {
+        // TO DO: I'm not sure if this function is done correctly
         if (this.content.feed.isLocalScreen) {
           return "Screen sharing stopped";
         } else {
-          return this.content.feed.display + " has left the room";
+          return "";
         }
       };
 

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -179,11 +179,11 @@
             // One of the publishers has gone away?
             } else if(msg.leaving !== undefined && msg.leaving !== null) {
               var leaving = msg.leaving;
-              ActionService.destroyFeed(leaving);
+              ActionService.destroyFeedLeaving;
             // One of the publishers has unpublished?
             } else if(msg.unpublished !== undefined && msg.unpublished !== null) {
               var unpublished = msg.unpublished;
-              ActionService.destroyFeed(unpublished);
+              ActionService.destroyFeedUnpublish;
             // Reply to a configure request
             } else if (msg.configured) {
               connection.confirmConfig();
@@ -411,7 +411,7 @@
     }
 
     function unPublishFeed(feedId) {
-      ActionService.destroyFeed(feedId);
+      ActionService.destroyFeedUnpublish;
     }
 
     function ignoreFeed(feedId) {

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -179,11 +179,11 @@
             // One of the publishers has gone away?
             } else if(msg.leaving !== undefined && msg.leaving !== null) {
               var leaving = msg.leaving;
-              ActionService.destroyFeedLeaving;
+              ActionService.destroyFeedLeaving(leaving);
             // One of the publishers has unpublished?
             } else if(msg.unpublished !== undefined && msg.unpublished !== null) {
               var unpublished = msg.unpublished;
-              ActionService.destroyFeedUnpublish;
+              ActionService.destroyFeedUnpublish(unpublished);
             // Reply to a configure request
             } else if (msg.configured) {
               connection.confirmConfig();
@@ -411,7 +411,7 @@
     }
 
     function unPublishFeed(feedId) {
-      ActionService.destroyFeedUnpublish;
+      ActionService.destroyFeedUnpublish(feedId);
     }
 
     function ignoreFeed(feedId) {


### PR DESCRIPTION
I split `destroyFeed()` into two functions: `destroyFeedLeaving()` and `destroyFeedUnpublish()`. It solves the issue #171 in a way suggested by ancorgs (https://github.com/jangouts/jangouts/pull/181#issuecomment-287382181).

I assumed that `destroyFeedUnpublish()` doesn't need any extra logs.

Also, I didn't live test it because I couldn't get Jangouts to run properly on my computer. I did `vagrant up`, `vagrant ssh` to login and then `gulp serve` to start a Jangouts server. I opened Jangouts on different browsers (Chrome, Firefox, Opera Neon), but clients cannot detect each other except for the login screen where they can detect the number of participants in a conference room.

I am not too familiar with Angular, but should we also consider making `destroyFeed()` private?

I am using macOS, Firefox 52.0.2, Opera Neon 1.0.2531.0 and Chrome 56.0.2924.87 (I turned off all plug-ins as well).