### PR TITLE
Added Event Emitter and Callstats Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 Vagrantfile
 .vagrant/
 src/config.json
+src/app/callstats/callstats.config.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ bower_components
 dist/
 Vagrantfile
 .vagrant/
-src/app/callstats/callstats.config.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ bower_components
 dist/
 Vagrantfile
 .vagrant/
-src/config.json
 src/app/callstats/callstats.config.json

--- a/bower.json
+++ b/bower.json
@@ -21,11 +21,12 @@
     "angular-gridster": "~0.13.5",
     "angular-extended-notifications": "~1.0.4",
     "angular-audio": "~1.7.1",
-    "angular-local-storage": "~0.2.3"
+    "angular-local-storage": "~0.2.3",
+    "rxjs": "^4.1.0"
   },
   "overrides": {
     "mousetrap": {
-        "main": "plugins/record/mousetrap-record.js"
+      "main": "plugins/record/mousetrap-record.js"
     }
   },
   "devDependencies": {

--- a/src/app/callstats/callstats.config.json
+++ b/src/app/callstats/callstats.config.json
@@ -1,4 +1,0 @@
-{
-  "AppID": "724446896",
-  "AppSecret": "/BKw/++t+DXe:UCxvwuXdkE6AIuxHXRj5PnaKLNeAgNZdp6rGShdWNmc="
-}

--- a/src/app/callstats/callstats.config.json
+++ b/src/app/callstats/callstats.config.json
@@ -1,0 +1,4 @@
+{
+  "AppID": "724446896",
+  "AppSecret": "/BKw/++t+DXe:UCxvwuXdkE6AIuxHXRj5PnaKLNeAgNZdp6rGShdWNmc=" 
+}

--- a/src/app/callstats/callstats.config.json
+++ b/src/app/callstats/callstats.config.json
@@ -1,0 +1,4 @@
+{
+  "AppID": "724446896",
+  "AppSecret": "/BKw/++t+DXe:UCxvwuXdkE6AIuxHXRj5PnaKLNeAgNZdp6rGShdWNmc="
+}

--- a/src/app/callstats/callstats.config.json.sample
+++ b/src/app/callstats/callstats.config.json.sample
@@ -1,4 +1,4 @@
 {
-  "AppID": null,
-  "AppSecret": null
+  "AppID": "724446896",
+  "AppSecret": "/BKw/++t+DXe:UCxvwuXdkE6AIuxHXRj5PnaKLNeAgNZdp6rGShdWNmc=" 
 }

--- a/src/app/callstats/callstats.config.json.sample
+++ b/src/app/callstats/callstats.config.json.sample
@@ -1,4 +1,4 @@
 {
-  "AppID": "724446896",
-  "AppSecret": "/BKw/++t+DXe:UCxvwuXdkE6AIuxHXRj5PnaKLNeAgNZdp6rGShdWNmc=" 
+  "AppID": null,
+  "AppSecret": null 
 }

--- a/src/app/callstats/callstats.config.json.sample
+++ b/src/app/callstats/callstats.config.json.sample
@@ -1,0 +1,4 @@
+{
+  "AppID": null,
+  "AppSecret": null
+}

--- a/src/app/callstats/callstats.provider.js
+++ b/src/app/callstats/callstats.provider.js
@@ -1,0 +1,226 @@
+/** 
+ * @file      callstats.provider.js
+ * @author    Bimalkant Lauhny <lauhny.bimalk@gmail.com>
+ * @copyright MIT License
+ * @brief     A service that subscribes to eventsObservable
+ *            and send stats to callstats.io
+ */
+
+(function () {
+  'use strict';
+
+  angular.module('CallstatsModule', [])
+    .provider('Callstats',  Callstats);
+
+  /**
+   * Module to communicate with callstats
+   */
+  function Callstats() {
+    // Step 1: Include callstats.js - done {index.html}
+    var callstatsConfig = {
+      // AppID is provided by callstats.io, set it inside callstats/callstats.config.json
+      AppID: null,
+      // AppSecret is provided by callstats.io, set it inside callstats/callstats.config.json
+      AppSecret: null,
+      /**
+       * callstats object is accessible as new window.callstats()
+       * this is set inside index.js (see .run())
+       */
+      callstats: null,
+ 
+      // Step 2: Initialize with AppSecret
+      /**
+       * Initialize the app with application tokens
+       * @param {string} localUserID - display of the user
+       */
+      initializeCallstats: function (localUserID) {
+        
+        console.log("Received localUserID: ", localUserID);
+        var res = this.callstats.initialize(this.AppID,
+                                            this.AppSecret,
+                                            localUserID,
+                                            csInitCallback,
+                                            csStatsCallback,
+                                            configParams);
+        
+        console.log("callstats.initialize response object", res);
+        /**
+         * reports different success and failure cases
+         * @param {string} csErrMsg - a descriptive error returned by callstats.io
+         */
+        function csInitCallback(csError, csErrMsg) {
+          console.log("Initialize return status: errCode= " + csError + " errMsg= " + csErrMsg );
+        }
+        
+        var reportType = {
+          inbound: 'inbound',
+          outbound: 'outbound'
+        };
+        
+        /**
+         * callback function to receive the stats
+         * @param stats
+         */
+        function csStatsCallback (stats) {
+          console.log("These are Initialize recieved stats: ", stats);
+          var ssrc;
+          for (ssrc in stats.streams) {
+            console.log("SSRC is: ", ssrc);
+            var dataSsrc = stats.streams[ssrc];
+            console.log("SSRC Type ", dataSsrc.reportType);
+            if (dataSsrc.reportType === reportType.outbound) {
+              console.log("RTT is: ", dataSsrc.rtt);
+            } else if (dataSsrc.reportType === reportType.inbound) {
+              console.log("Inbound loss rate is: ", dataSsrc.fractionLoss);
+            }
+          }
+        }
+        
+        var configParams = {
+          disableBeforeUnloadHandler: false, // disables callstats.js's window.onbeforeunload parameter.
+          applicationVersion: "0.4.6" // Application version specified by the developer.
+        };
+        
+      },
+      
+      // Step 3: Pass the PeerConnection object to the library - adding new Fabric
+      /**
+       * function for sending PeerConnection Object
+       * @param {object} pcObject - RTCPeerConnectionObject
+       */
+      sendPCObject: function (pcObject, remoteUserID, conferenceID) {
+        console.log("Send PC Object Parameters: ", pcObject, remoteUserID, conferenceID);
+        // PeerConnection carrying multiple media streams on the same port
+        var usage = this.callstats.fabricUsage.multiplex;
+        
+        /**
+         * callback asynchronously reporting failure or success for pcObject.
+         * @param msg error message
+         */
+        function pcCallback (err, msg) {
+          console.log("Monitoring status: "+ err + " msg: " + msg);
+        }
+        
+        if (remoteUserID && conferenceID && pcObject) {
+          this.callstats.addNewFabric(pcObject, remoteUserID, usage, conferenceID, pcCallback);
+        } else {
+          console.log("ERROR: Faulty Parameters! ", pcObject, remoteUserID, conferenceID);
+        }
+        
+      },
+      
+      // Step 4: Error Reporting
+      /**
+       * function reporting error and WebRTC functionType to callstats.io
+       * @param err DomError
+       * @param functionType WebRTC function in which error occurred
+       */
+      reportErrors: function (pcObject, conferenceID, err, functionType) {
+        console.log("::: reporting error ::: ", err, functionType);
+        this.callstats.reportError(pcObject, conferenceID, this.callstats.webRTCFunctions[functionType], err);
+      },
+      
+      // OPTIONAL STEPS
+      
+      // Step 5: Send fabric events
+      /**
+       * function reporting fabric events to callstats.io
+       * @param {string} event - eventType for userEvents
+       */
+      sendEvents: function (pcObject, conferenceID, event) {
+        console.log("::: Sending Event ::: ", event);
+        this.callstats.sendFabricEvent(pcObject, this.callstats.fabricEvent[event], conferenceID);
+      },
+ 
+      /**
+       * function subscribing to eventsProvider subject and providing eventHandler 
+       * @param Observable 
+       */
+      subscribeToEventsSubject: function(Observable) {
+      
+        Observable.subscribe(eventHandler.bind(this));
+        
+        function eventHandler(event) {
+          console.log("Received Event: ", event);
+          var eventType = event.type;
+          switch(eventType) {
+            case 'user':
+              if (event.data.status === "joining") {
+                // new user joined
+                this.initializeCallstats(event.username);
+              }
+              break;
+            case 'subscriber':
+              break;
+            case 'stream':
+              if (event.data.stream === "local" && event.data.for === "main") {
+                this.sendPCObject(event.data.peerconnection, "Janus", event.roomDesc);
+              } else if (event.data.stream === "remote" && event.data.for === "subscriber") {
+                this.sendPCObject(event.data.peerconnection, "Janus", event.roomDesc);
+              }
+              break;
+              
+            case 'screenshare':
+              if (event.data.status === "started") {
+                // screenshare started
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "screenShareStart");
+              } else if (event.data.status === "stopped") {
+                // screenshare stopped
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "screenShareStop");
+              }
+              break;
+              
+            case 'video':
+              if (event.data.status === "paused") {
+                // Video paused 
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "videoPause");
+              } else if (event.data.status === "resumed") {
+                // Video resumed 
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "videoResumed");
+              }
+              break;
+              
+            case 'audio':
+              if (event.data.status === "muted") {
+                // Audio Muted
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "audioMute");
+              } else if (event.data.status === "unmuted") {
+                // Audio Unmuted 
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "audioUnmute");
+              }
+              break;
+              
+            case 'pluginHandle':
+              if (event.data.status === "detached" && event.data.for === "main") {
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "fabricTerminated");
+              } else if (event.data.status === "detached" && event.data.for === "subscriber") {
+                this.sendEvents(event.data.peerconnection, event.roomDesc, "fabricTerminated");
+              }
+              break;
+              
+            case 'error':
+              if (event.data.status === "createOffer") {
+                this.reportErrors(event.data.peerconnection, event.roomDesc, event.data.error, "createOffer");
+              } else if (event.data.status === "createAnswer") {
+                this.reportErrors(event.data.peerconnection, event.roomDesc, event.data.error, "createAnswer");
+              }
+              break;
+              
+            default: 
+              console.log("Unknown type of event: ", event);
+              break;
+          }
+        }
+      }
+    }; 
+    
+    return {
+      $get: function() {
+        return callstatsConfig;
+      },
+      $set: function(key, val) {
+        callstatsConfig[key] = val;
+      }
+    };
+  }
+}());

--- a/src/app/components/feed/feed-connection.factory.js
+++ b/src/app/components/feed/feed-connection.factory.js
@@ -11,7 +11,7 @@
   angular.module('janusHangouts')
     .factory('FeedConnection', feedConnectionFactory);
 
-  feedConnectionFactory.$inject = ['ConnectionConfig'];
+  feedConnectionFactory.$inject = ['ConnectionConfig', 'jhEventsProvider'];
 
   /**
    * Manages the connection of a feed to the Janus server
@@ -27,7 +27,7 @@
    *  former to share the whole screen and the latter for sharing individual
    *  windows.
    */
-  function feedConnectionFactory(ConnectionConfig) {
+  function feedConnectionFactory(ConnectionConfig, jhEventsProvider) {
     return function(pluginHandle, roomId, role) {
       var that = this;
 
@@ -38,6 +38,14 @@
       console.log(this.role + " plugin attached (" + pluginHandle.getPlugin() + ", id=" + pluginHandle.getId() + ")");
 
       this.destroy = function() {
+        // emit 'handle detached' event
+        jhEventsProvider.emitEvent({
+          type: "pluginHandle",
+          data: {
+            status: "detached",
+            pluginHandle: pluginHandle
+          }
+        });
         this.config = null;
         this.pluginHandle.detach();
       };
@@ -107,6 +115,15 @@
           error: function(error) {
             console.error("WebRTC error publishing");
             console.error(error);
+            // emit 'error Create Offer' event
+            jhEventsProvider.emitEvent({
+              type: "error",
+              data: {
+                status: "createOffer",
+                error: error,
+                peerconnection: that.pluginHandle.webrtcStuff.pc
+              }
+            });
             // Call the provided callback for extra actions
             if (options.error) { options.error(); }
           }
@@ -134,6 +151,15 @@
           error: function(error) {
             console.error("WebRTC error subscribing");
             console.error(error);
+            // emit 'error CreateAnswer' event
+            jhEventsProvider.emitEvent({
+              type: "error",
+              data: {
+                status: "createAnswer",
+                error: error,
+                peerconnection: that.pluginHandle.webrtcStuff.pc
+              }
+            });
           }
         });
       };

--- a/src/app/components/feed/feed-connection.factory.js
+++ b/src/app/components/feed/feed-connection.factory.js
@@ -43,7 +43,8 @@
           type: "pluginHandle",
           data: {
             status: "detached",
-            pluginHandle: pluginHandle
+            for: that.role,
+            pluginHandle: that.pluginHandle
           }
         });
         this.config = null;

--- a/src/app/components/feed/feeds.factory.js
+++ b/src/app/components/feed/feeds.factory.js
@@ -15,7 +15,7 @@
   angular.module('janusHangouts')
     .factory('Feed', feedFactory);
 
-  feedFactory.$inject = ['$timeout', 'DataChannelService', 'SpeakObserver', 
+  feedFactory.$inject = ['$timeout', 'DataChannelService', 'SpeakObserver',
                          'jhEventsProvider'];
 
   /**
@@ -23,7 +23,7 @@
    * @constructor
    * @memberof module:janusHangouts
    */
-  function feedFactory($timeout, DataChannelService, SpeakObserver, 
+  function feedFactory($timeout, DataChannelService, SpeakObserver,
                        jhEventsProvider) {
     return function(attrs) {
       attrs = attrs || {};
@@ -292,26 +292,17 @@
                 if (options.after) { options.after(); }
                 // Send the new status to remote peers
                 DataChannelService.sendStatus(that, {exclude: "picture"});
-                
-                if (type === 'video') { 
-                  // Sending videoPause OR videoResume event to callstats.io
-                  jhEventsProvider.emitEvent({
-                    type: "video",
-                    data: {
-                      status: ((enabled === false) ? "paused" : "resumed"),
-                      peerconnection: that.connection.pluginHandle.webrtcStuff.pc
-                    }
-                  });
-                } else if (type === 'audio') {
-                  // Sending audioMute OR audioUnmute event to callstats.io
-                  jhEventsProvider.emitEvent({
-                    type: "audio",
-                    data: {
-                      status: ((enabled === false) ? "muted" : "unmuted"),
-                      peerconnection: that.connection.pluginHandle.webrtcStuff.pc
-                    }
-                  });
-                }
+
+                // send 'channel' event with status (enabled or disabled)
+                jhEventsProvider.emitEvent({
+                  type: "channel",
+                  data: {
+                    channel: type,
+                    status: enabled,
+                    peerconnection: that.connection.pluginHandle.webrtcStuff.pc
+                  }
+                });
+
               });
             }
           });
@@ -355,7 +346,7 @@
           DataChannelService.sendStatus(that);
         });
       };
-      
+
       /**
        * Updates the value of the display attribute for this publisher feed,
        * notifying changes to the remote peers.
@@ -376,10 +367,10 @@
       this.getDisplay = function() {
         return this.display;
       };
-    
+
       /**
-       * Sets the name for publisher 
-       * @param {string} - val - new display 
+       * Sets the name for publisher
+       * @param {string} - val - new display
        */
       this.setDisplay = function (val) {
         this.display = val;

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -129,7 +129,7 @@
             type: "pluginHandle",
             data: {
               status: "attached",
-              for: "user",
+              for: "main",
               pluginHandle: pluginHandle
             }
           });
@@ -166,7 +166,7 @@
             type: "stream",
             data: {
               stream: "local",
-              for: "user",
+              for: "main",
               peerconnection: connection.pluginHandle.webrtcStuff.pc
             }
           });
@@ -445,7 +445,7 @@
             type: "pluginHandle",
             data: {
               status: "attached",
-              for: "screenshare",
+              for: "screen",
               pluginHandle: pluginHandle
             }
           });
@@ -466,7 +466,7 @@
             type: "stream",
             data: {
               stream: "local",
-              for: "screenshare",
+              for: "screen",
               peerconnection: connection.pluginHandle.webrtcStuff.pc
             }
           });

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -13,7 +13,7 @@
 
     RoomService.$inject = ['$q', '$rootScope', '$timeout', 'FeedsService', 'Room',
       'FeedConnection', 'DataChannelService', 'ActionService', 'jhConfig',
-      'ScreenShareService', 'RequestService', 'UserService'];
+      'ScreenShareService', 'RequestService', 'UserService', 'jhEventsProvider'];
 
   /**
    * Service to communication with janus room
@@ -22,7 +22,7 @@
    */
   function RoomService($q, $rootScope, $timeout, FeedsService, Room,
       FeedConnection, DataChannelService, ActionService, jhConfig,
-      ScreenShareService, RequestService, UserService) {
+      ScreenShareService, RequestService, UserService, jhEventsProvider) {
     this.enter = enter;
     this.leave = leave;
     this.setRoom = setRoom;
@@ -106,6 +106,9 @@
       var $$rootScope = $rootScope;
       var connection = null;
 
+      // adding room details to jhEventsProvider
+      jhEventsProvider.roomDesc = that.room.description;
+      
       // Create new session
       that.janus.attach({
         plugin: "janus.plugin.videoroom",
@@ -230,6 +233,9 @@
 
     // Enter the room
     function enter(username) {
+      // adding username to jhEventsProvider
+      jhEventsProvider.username = username;
+      
       var deferred = $q.defer();
 
       connect().then(function () {

--- a/src/app/events/events.provider.js
+++ b/src/app/events/events.provider.js
@@ -26,7 +26,6 @@
           event.roomDesc = this.roomDesc;
           // timestamp shows the time when event gets emitted
           event.timestamp = Date.now();
-          console.log('Created Event: ', event);
           this.eventsSubject.onNext(event);
         }
     };

--- a/src/app/events/events.provider.js
+++ b/src/app/events/events.provider.js
@@ -1,0 +1,42 @@
+/**
+ * @file      events.provider.js
+ * @author    Bimalkant Lauhny <lauhny.bimalk@gmail.com>
+ * @copyright MIT License
+ * @brief     Creates an event emitter using a subject observable
+ *            to which different services can subscribe
+ */
+(function () {
+  'use strict';
+
+  angular.module("janusHangouts.eventsProvider", [])
+    .provider('jhEventsProvider', function () {
+      var eventsConfig = {
+        // username stores name of the user
+        username: null,
+        // roomDesc stores room name
+        roomDesc: null,
+        // eventsSubject stores a reference to window.Rx object
+        eventsSubject: null,
+        /**
+         *  Emits event after adding opaqueId and timestamp to it 
+         *  @param {object} event - carries 'type' and 'data' for event
+         */
+        emitEvent: function (event) {
+          event['username'] = this.username; 
+          event['roomDesc'] = this.roomDesc;
+          // timestamp shows the time when event gets emitted
+          event['timestamp'] = Date.now();
+          this.eventsSubject.onNext(event);
+        }
+    };
+      
+      return {
+        $get: function () {
+          return eventsConfig;
+        },
+        $set: function(key, val) {
+          eventsConfig[key] = val;
+        }
+      };
+    });
+})();

--- a/src/app/events/events.provider.js
+++ b/src/app/events/events.provider.js
@@ -22,10 +22,11 @@
          *  @param {object} event - carries 'type' and 'data' for event
          */
         emitEvent: function (event) {
-          event['username'] = this.username; 
-          event['roomDesc'] = this.roomDesc;
+          event.username = this.username; 
+          event.roomDesc = this.roomDesc;
           // timestamp shows the time when event gets emitted
-          event['timestamp'] = Date.now();
+          event.timestamp = Date.now();
+          console.log('Created Event: ', event);
           this.eventsSubject.onNext(event);
         }
     };

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -7,10 +7,11 @@
 
 'use strict';
 
-angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch',
-               'ngSanitize', 'blockUI', 'ui.router', 'ui.bootstrap', 'ngEmbed',
-               'janusHangouts.config', 'janusHangouts.eventsProvider', 'cfp.hotkeys', 'gridster',
-               'ngAudio', 'angular-extended-notifications', 'LocalStorageModule'])
+angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch', 'ngSanitize',
+               'blockUI', 'ui.router', 'ui.bootstrap', 'ngEmbed', 'cfp.hotkeys',
+               'janusHangouts.config', 'janusHangouts.eventsProvider', 'gridster',
+               'CallstatsModule', 'ngAudio', 'angular-extended-notifications', 
+               'LocalStorageModule'])
   .config(function ($stateProvider, $urlRouterProvider) {
     $stateProvider
       .state('signin', {
@@ -93,13 +94,38 @@ angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch',
       console.warn('No configuration found');
     }
   })
-  .run(function(jhEventsProvider){
+  .run(function($http, jhEventsProvider, Callstats){
+    
     // setting Rx Subject
     jhEventsProvider.eventsSubject = new window.Rx.Subject();
     if (jhEventsProvider.eventsSubject === null ||
         jhEventsProvider.eventsSubject === undefined) {
       console.log("Could not load rx.js! Event emitter will not work.");
     }
+    
+    // reading callstats.config.json
+    var request = new XMLHttpRequest();
+    request.open('GET', 'app/callstats/callstats.config.json', false);
+    request.send(null);
+    if (request.status === 200) {
+      var config = JSON.parse(request.responseText);
+      angular.forEach(config, function (value, key) {
+        //assigning config value with replaced value of placeholder
+        Callstats[key] = value;
+      });
+    } else {
+      console.warn('No Callstats configuration found!');
+    } 
+    
+    // setting callstats object
+    Callstats.callstats = new window.callstats();
+    if (Callstats.callstats === null ||
+        Callstats.callstats === undefined) {
+      console.log("Could not load callstats.min.js!");
+    }
+    
+    // enabling callstatsModule to receive events by subscribing to the events Subject
+    Callstats.subscribeToEventsSubject(jhEventsProvider.eventsSubject);
   })
   .run(function ($rootScope, $state, RoomService) {
     $rootScope.$on('$stateChangeStart', function () {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -9,7 +9,7 @@
 
 angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch',
                'ngSanitize', 'blockUI', 'ui.router', 'ui.bootstrap', 'ngEmbed',
-               'janusHangouts.config', 'cfp.hotkeys', 'gridster',
+               'janusHangouts.config', 'janusHangouts.eventsProvider', 'cfp.hotkeys', 'gridster',
                'ngAudio', 'angular-extended-notifications', 'LocalStorageModule'])
   .config(function ($stateProvider, $urlRouterProvider) {
     $stateProvider
@@ -91,6 +91,14 @@ angular.module('janusHangouts', ['ngAnimate', 'ngCookies', 'ngTouch',
       });
     } else {
       console.warn('No configuration found');
+    }
+  })
+  .run(function(jhEventsProvider){
+    // setting Rx Subject
+    jhEventsProvider.eventsSubject = new window.Rx.Subject();
+    if (jhEventsProvider.eventsSubject === null ||
+        jhEventsProvider.eventsSubject === undefined) {
+      console.log("Could not load rx.js! Event emitter will not work.");
     }
   })
   .run(function ($rootScope, $state, RoomService) {

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,9 @@
+{
+  "janusServer": null,
+  "janusServerSSL": "https://localhost:8089/janus",
+  "janusDebug": false,
+  "httpsAvailable": true,
+  "httpsUrl": null,
+  "videoThumbnails": true,
+  "joinUnmutedLimit": 3
+}

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,8 @@
     <div ui-view class="container-fluid container-no-padding"></div>
 
     <jh-footer></jh-footer>
-
+    
+    <script src="https://api.callstats.io/static/callstats.min.js"></script>
     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->
     <!-- run `gulp inject` to automatically populate bower script dependencies -->


### PR DESCRIPTION
This PR adds:

    1.  Event emitter support to Jangouts 
I've used RxJS (thanks to @imobachgs for suggestion). The `events.provider.js` is a module that 
provides an interface in form of a `Subject` to which any external service can subscribe to receive 
events. These events, then, can be used by services according to their use cases.

    2.  Callstats Service Integration
I've added `callstats.provider.js` as a module that reads callstats user configuration from 
`callstats.config.json` file. It subscribes to the event emitter and recieves events, which, it then
sends to the callstats.io service.
