### PR TITLE
Initialize state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10605,6 +10605,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-redux": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.0.tgz",
+      "integrity": "sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "react-resizable": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.8.0.tgz",
@@ -10789,6 +10812,15 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -12084,8 +12116,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-grid-layout": "^0.16.6",
+    "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.0.1",
+    "redux": "^4.0.1",
     "rxjs": "^6.5.2",
     "webrtc-adapter": "^7.2.4"
   },
@@ -28,7 +30,11 @@
   },
   "lint-staged": {
     "linters": {
-      "*.js": [ "eslint", "prettier --write", "git add" ]
+      "*.js": [
+        "eslint",
+        "prettier --write",
+        "git add"
+      ]
     }
   },
   "browserslist": {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import {BrowserRouter, Route} from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { BrowserRouter, Route } from 'react-router-dom';
+
+import store from '../../state/store';
+
 import Login from '../Login';
 import Room from '../Room';
 
@@ -7,10 +11,12 @@ import './App.css';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Route exact path="/" component={Login} />
-      <Route path="/room" component={Room} />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <Route exact path="/" component={Login} />
+        <Route path="/room" component={Room} />
+      </BrowserRouter>
+    </Provider>
   );
 }
 

--- a/src/state/ducks/index.js
+++ b/src/state/ducks/index.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+
+import participantsReducer from './participants';
+
+export default combineReducers({
+  participants: participantsReducer
+});

--- a/src/state/ducks/index.js
+++ b/src/state/ducks/index.js
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
 
+import roomReducer from './room';
 import participantsReducer from './participants';
 import messagesReducer from './messages';
 
 export default combineReducers({
+  room: roomReducer,
   participants: participantsReducer,
   messages: messagesReducer
 });

--- a/src/state/ducks/index.js
+++ b/src/state/ducks/index.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 
 import participantsReducer from './participants';
+import messagesReducer from './messages';
 
 export default combineReducers({
-  participants: participantsReducer
+  participants: participantsReducer,
+  messages: messagesReducer
 });

--- a/src/state/ducks/messages.js
+++ b/src/state/ducks/messages.js
@@ -1,0 +1,44 @@
+const MESSAGE_SENT = 'jangouts/message/SEND';
+const MESSAGE_RECEIVED = 'jangouts/message/RECEIVE';
+
+const sendMessage = message => ({
+  type: MESSAGE_SENT,
+  payload: message
+});
+
+const receiveMessage = message => ({
+  type: MESSAGE_RECEIVED,
+  payload: message
+});
+
+const actionCreators = {
+  sendMessage,
+  receiveMessage
+};
+
+const actionTypes = {
+  MESSAGE_SENT,
+  MESSAGE_RECEIVED
+};
+
+const initialState = {};
+
+const reducer = function(state = initialState, action) {
+  switch (action.type) {
+    case MESSAGE_SENT:
+    case MESSAGE_RECEIVED: {
+      const message = action.payload;
+
+      return {
+        ...state,
+        [message.id]: message
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export { actionCreators, actionTypes };
+
+export default reducer;

--- a/src/state/ducks/messages.test.js
+++ b/src/state/ducks/messages.test.js
@@ -1,0 +1,57 @@
+import reducer, { actionTypes, actionCreators } from './messages';
+
+const newMessage = { id: '5678', content: 'See you!', type: 'message' };
+
+describe('reducer', () => {
+  const initialState = {
+    '1234': { id: '1234', content: 'Hello!', type: 'message' }
+  };
+
+  it('does not handle unknown action', () => {
+    const action = { type: 'UNKNOWN', payload: newMessage };
+
+    expect(reducer(initialState, action)).toEqual(initialState);
+  });
+
+  it('handles MESSAGE_SENT', () => {
+    const action = { type: actionTypes.MESSAGE_SENT, payload: newMessage };
+
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      '5678': { id: '5678', content: 'See you!', type: 'message' }
+    });
+  });
+
+  it('handles MESSAGE_RECEIVED', () => {
+    const action = { type: actionTypes.MESSAGE_RECEIVED, payload: newMessage };
+
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      '5678': { id: '5678', content: 'See you!', type: 'message' }
+    });
+  });
+});
+
+describe('action creators', () => {
+  describe('#sendMessage', () => {
+    it('creates an action to send a message', () => {
+      const expectedAction = {
+        type: actionTypes.MESSAGE_SENT,
+        payload: newMessage
+      };
+
+      expect(actionCreators.sendMessage(newMessage)).toEqual(expectedAction);
+    });
+  });
+
+  describe('#receiveMessage', () => {
+    it('creates an action to received a message', () => {
+      const expectedAction = {
+        type: actionTypes.MESSAGE_RECEIVED,
+        payload: newMessage
+      };
+
+      expect(actionCreators.receiveMessage(newMessage)).toEqual(expectedAction);
+    });
+  });
+});

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -1,0 +1,52 @@
+const PARTICIPANT_JOINED = 'jangouts/participant/JOIN';
+const PARTICIPANT_DETACHED = 'jangouts/participant/DETACH';
+
+const addParticipant = participant => ({
+  type: PARTICIPANT_JOINED,
+  payload: participant
+});
+
+const removeParticipant = participant => ({
+  type: PARTICIPANT_DETACHED,
+  payload: participant
+});
+
+const actionCreators = {
+  addParticipant,
+  removeParticipant
+};
+
+const actionTypes = {
+  PARTICIPANT_JOINED,
+  PARTICIPANT_DETACHED
+};
+
+const initialState = {};
+
+const reducer = function(state = initialState, action) {
+  switch (action.type) {
+    case PARTICIPANT_JOINED: {
+      const participant = action.payload;
+
+      return {
+        ...state,
+        [participant.id]: participant
+      };
+    }
+
+    case PARTICIPANT_DETACHED: {
+      return Object.keys(state)
+        .filter(key => key !== action.payload.id)
+        .reduce((obj, key) => {
+          obj[key] = state[key];
+          return obj;
+        }, {});
+    }
+    default:
+      return state;
+  }
+};
+
+export { actionCreators, actionTypes };
+
+export default reducer;

--- a/src/state/ducks/participants.test.js
+++ b/src/state/ducks/participants.test.js
@@ -1,0 +1,67 @@
+import reducer, { actionTypes, actionCreators } from './participants';
+
+describe('reducer', () => {
+  const initialState = {
+    user: { username: 'user' }
+  };
+
+  it('does not handle unknown action', () => {
+    const action = {
+      type: 'UNKNOWN',
+      payload: { id: 'otherUser', username: 'otherUser' }
+    };
+
+    expect(reducer(initialState, action)).toEqual(initialState);
+  });
+
+  it('handles PARTICIPANT_JOINED', () => {
+    const action = {
+      type: actionTypes.PARTICIPANT_JOINED,
+      payload: { id: 'otherUser', username: 'otherUser' }
+    };
+
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      otherUser: { id: 'otherUser', username: 'otherUser' }
+    });
+  });
+
+  it('handles PARTICIPANT_DETACHED', () => {
+    const action = {
+      type: actionTypes.PARTICIPANT_DETACHED,
+      payload: { id: 'user', username: 'user' }
+    };
+
+    expect(reducer(initialState, action)).toEqual({});
+  });
+});
+
+describe('action creators', () => {
+  describe('#addParticipant', () => {
+    it('creates an action to add a participant', () => {
+      const participant = { id: 'jangouts', username: 'jangouts' };
+      const expectedAction = {
+        type: actionTypes.PARTICIPANT_JOINED,
+        payload: participant
+      };
+
+      expect(actionCreators.addParticipant(participant)).toEqual(
+        expectedAction
+      );
+    });
+  });
+
+  describe('#removeParticipant', () => {
+    it('creates an action to detach a participant', () => {
+      const participant = { id: 'jangouts', username: 'jangouts' };
+      const expectedAction = {
+        type: actionTypes.PARTICIPANT_DETACHED,
+        payload: participant
+      };
+
+      expect(actionCreators.removeParticipant(participant)).toEqual(
+        expectedAction
+      );
+    });
+  });
+});

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -1,0 +1,34 @@
+const ROOM_ENTER = 'jangouts/room/ENTER';
+const ROOM_EXIT = 'jangouts/room/EXIT';
+
+const enterRoom = room => ({ type: ROOM_ENTER, payload: room });
+const exitRoom = room => ({ type: ROOM_EXIT });
+
+const actionCreators = {
+  enterRoom,
+  exitRoom
+};
+
+const actionTypes = {
+  ROOM_ENTER,
+  ROOM_EXIT
+};
+
+const initialState = {};
+
+const reducer = function(state = initialState, action) {
+  switch (action.type) {
+    case ROOM_ENTER: {
+      return action.payload;
+    }
+    case ROOM_EXIT: {
+      return initialState;
+    }
+    default:
+      return state;
+  }
+};
+
+export { actionCreators, actionTypes };
+
+export default reducer;

--- a/src/state/ducks/room.test.js
+++ b/src/state/ducks/room.test.js
@@ -1,0 +1,46 @@
+import reducer, { actionTypes, actionCreators } from './room';
+
+const room = { id: 'misc', name: 'Misc' };
+
+describe('reducer', () => {
+  const initialState = {};
+
+  it('does not handle unknown action', () => {
+    const action = { type: 'UNKNOWN', payload: room };
+
+    expect(reducer(initialState, action)).toEqual(initialState);
+  });
+
+  it('handles ROOM_ENTER', () => {
+    const action = { type: actionTypes.ROOM_ENTER, payload: room };
+
+    expect(reducer(initialState, action)).toEqual(room);
+  });
+
+  it('handles ROOM_EXIT', () => {
+    const action = { type: actionTypes.ROOM_EXIT };
+
+    expect(reducer(initialState, action)).toEqual({});
+  });
+});
+
+describe('action creators', () => {
+  describe('#enterRoom', () => {
+    it('creates an action to enter in a room', () => {
+      const expectedAction = {
+        type: actionTypes.ROOM_ENTER,
+        payload: room
+      };
+
+      expect(actionCreators.enterRoom(room)).toEqual(expectedAction);
+    });
+  });
+
+  describe('#exitRoom', () => {
+    it('creates an action to exit of a room', () => {
+      const expectedAction = { type: actionTypes.ROOM_EXIT };
+
+      expect(actionCreators.exitRoom(room)).toEqual(expectedAction);
+    });
+  });
+});

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,0 +1,6 @@
+import { createStore, combineReducers } from 'redux';
+
+export default createStore(
+  combineReducers({}),
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,6 +1,7 @@
-import { createStore, combineReducers } from 'redux';
+import { createStore } from 'redux';
+import reducers from './ducks';
 
 export default createStore(
-  combineReducers({}),
+  reducers,
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 );


### PR DESCRIPTION
A basic initialization of the app state, which will be handle by [Redux]() state container. It could be considered as a simple starting point, which sketch

* room
* participants
* messages


Please, keep in mind that, after a brief discussion, we decided to structure the _state ecosystem_ following an _approximation_ to the [ducks modular approach proposal](https://github.com/erikras/ducks-modular-redux). 

  > ### Rules
  > 
  > A module...
  > 
  > 1. MUST `export default` a function called `reducer()`
  > 2. MUST `export` its action creators as functions
  > 3. MUST have action types in the form `npm-module-or-app/reducer/ACTION_TYPE`
  > 4. MAY export its action types as `UPPER_SNAKE_CASE`, if an external reducer needs to listen for them, or if it is a published reusable library.
  >
  >  https://github.com/erikras/ducks-modular-redux#rules

There are other approaches on top of that, using directories, but we want to start with a file per _duck_.
