### PR TITLE
Add initial support for docker-compose

### DIFF
--- a/Dockerfile.janus
+++ b/Dockerfile.janus
@@ -1,0 +1,22 @@
+FROM opensuse/leap:15.0
+
+RUN zypper --non-interactive in --no-recommends curl && zypper clean -a
+
+RUN curl --insecure -L -O https://build.opensuse.org/projects/network:jangouts/public_key \
+  && rpm --import public_key \
+  && rm public_key
+
+RUN zypper ar -f -r \
+  https://download.opensuse.org/repositories/network:/jangouts/openSUSE_Leap_15.0/network:jangouts.repo \
+  && zypper --non-interactive in --no-recommends janus-gateway \
+  && zypper clean -a
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 8088
+EXPOSE 8089
+EXPOSE 8188
+EXPOSE 8189
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["janus"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  janus:
+    image: "janus-gateway"
+    build:
+      context: "."
+      dockerfile: "Dockerfile.janus"
+    ports:
+      - "127.0.0.1:8188:8188"
+      - "127.0.0.1:8088:8088"
+      - "127.0.0.1:8989:8989"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ ! -f /etc/janus/cert.pem ]
+then
+  /usr/bin/openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /etc/janus/cert.key -out /etc/janus/cert.pem \
+    -subj "/C=DE/CN=jangouts.local"
+fi
+
+exec "$@"


### PR DESCRIPTION
Support for docker-compose. For the time being, only the Janus server is "containerized".

```
sudo zypper in python3-docker-compose
docker-compose build janus
docker-compose up janus
```