### PR TITLE
Emit events on muting

### DIFF
--- a/src/janus-api/data-channel-service.js
+++ b/src/janus-api/data-channel-service.js
@@ -7,7 +7,11 @@
 
 import { createLogEntry } from './models/log-entry';
 
-export const createDataChannelService = (feedsService, logService) => {
+export const createDataChannelService = (
+  feedsService,
+  logService,
+  eventsService
+) => {
   let that = {};
 
   that.receiveMessage = (data, remoteId) => {
@@ -17,39 +21,48 @@ export const createDataChannelService = (feedsService, logService) => {
     var feed;
     var logEntry;
 
-    if (type === "chatMsg") {
-      logEntry = createLogEntry("chatMsg", {feed: feedsService.find(remoteId), text: content});
+    if (type === 'chatMsg') {
+      logEntry = createLogEntry('chatMsg', {
+        feed: feedsService.find(remoteId),
+        text: content
+      });
       if (logEntry.hasText()) {
         logService.add(logEntry);
       }
-    } else if (type === "muteRequest") {
+    } else if (type === 'muteRequest') {
       feed = feedsService.find(content.target);
-      /* TODO $rootScope
       if (feed.isPublisher) {
-        feed.setEnabledChannel("audio", false, {after:
-          function() { $rootScope.$broadcast('muted.byRequest'); }
+        feed.setEnabledChannel('audio', false, {
+          after: after: function() {
+            eventsService.emitEvent({
+              type: 'muted',
+              data: { by: 'request' }
+            });
+          }
         });
       }
-      END OF TODO */
       // Log the event
-      logEntry = createLogEntry("muteRequest", {source: feedsService.find(remoteId), target: feed});
+      logEntry = createLogEntry('muteRequest', {
+        source: feedsService.find(remoteId),
+        target: feed
+      });
       logService.add(logEntry);
-    } else if (type === "statusUpdate") {
+    } else if (type === 'statusUpdate') {
       feed = feedsService.find(content.source);
       if (feed && !feed.isPublisher) {
         feed.setStatus(content.status);
       }
     } else {
-      console.log("Unknown data type: " + type);
+      console.log('Unknown data type: ' + type);
     }
   };
 
-  that.sendMuteRequest = (feed) => {
+  that.sendMuteRequest = feed => {
     var content = {
-      target: feed.id,
+      target: feed.id
     };
 
-    that.sendMessage("muteRequest", content);
+    that.sendMessage('muteRequest', content);
   };
 
   that.sendStatus = (feed, statusOptions) => {
@@ -58,11 +71,11 @@ export const createDataChannelService = (feedsService, logService) => {
       status: feed.getStatus(statusOptions)
     };
 
-    that.sendMessage("statusUpdate", content);
+    that.sendMessage('statusUpdate', content);
   };
 
-  that.sendChatMessage = (text) => {
-    that.sendMessage("chatMsg", text);
+  that.sendChatMessage = text => {
+    that.sendMessage('chatMsg', text);
   };
 
   that.sendMessage = (type, content) => {
@@ -71,18 +84,24 @@ export const createDataChannelService = (feedsService, logService) => {
       content: content
     });
     var mainFeed = feedsService.findMain();
-    if (mainFeed === null) { return; }
+    if (mainFeed === null) {
+      return;
+    }
     if (!mainFeed.isDataOpen()) {
-      console.log("Data channel not open yet. Skipping");
+      console.log('Data channel not open yet. Skipping');
       return;
     }
     var connection = mainFeed.connection;
     connection.sendData({
       text: text,
-      error: function(reason) { alert(reason); },
-      success: function() { console.log("Data sent: " + type); }
+      error: function(reason) {
+        alert(reason);
+      },
+      success: function() {
+        console.log('Data sent: ' + type);
+      }
     });
   };
 
   return that;
-}
+};

--- a/src/janus-api/data-channel-service.test.js
+++ b/src/janus-api/data-channel-service.test.js
@@ -7,8 +7,15 @@
 
 import { createDataChannelService } from './data-channel-service';
 import { createLogService } from './log-service';
+import { createFeedsService } from './feeds-service';
+import { createFeedFactory } from './models/feed';
+import { createFeedConnection } from './models/feed-connection';
 
 describe('#sendChatMessage', () => {
+  const eventsService = {
+    emitEvent: jest.fn()
+  };
+
   const mainConnection = {
     sendData: jest.fn()
   };
@@ -24,7 +31,11 @@ describe('#sendChatMessage', () => {
 
   test('sends the message through the main connection', () => {
     let logService = createLogService;
-    let dataService = createDataChannelService(feedsService, logService);
+    let dataService = createDataChannelService(
+      feedsService,
+      logService,
+      eventsService
+    );
 
     dataService.sendChatMessage("Hello Dolly!");
     var sentData = mainConnection.sendData.mock.calls;
@@ -43,28 +54,107 @@ describe('#receiveMessage', () => {
     add: jest.fn()
   };
 
-  const feed = {};
-
-  const feedsService = {
-    find: (id) => id === 1 ? feed : null
+  const eventsService = {
+    emitEvent: jest.fn()
   };
+
+  const feedsService = createFeedsService();
+
+  const dataService = createDataChannelService(
+    feedsService,
+    logService,
+    eventsService
+  );
+
+  const createFeed = createFeedFactory(dataService, eventsService);
+
+  const pluginHandle = {
+    getId: () => 1,
+    getPlugin: () => 'videoroom',
+    // Execute the callback if a confirmation is received
+    send: options => {
+      options['success']();
+    }
+  };
+  const createConnection = createFeedConnection(eventsService);
+
+  const publish_conn = createConnection(pluginHandle, 222, 'publisher');
+  const publish_feed = createFeed({
+    id: 1,
+    isPublisher: true,
+    connection: publish_conn
+  });
+  const subscribe_feed = createFeed({ id: 2 });
+
+  feedsService.add(publish_feed);
+  feedsService.add(subscribe_feed);
+
+  function last_log() {
+    var calls = logService.add.mock.calls;
+    var last_call = calls[calls.length - 1];
+    return last_call[0];
+  }
+
+  function last_event() {
+    var calls = eventsService.emitEvent.mock.calls;
+    var last_call = calls[calls.length - 1];
+    return last_call ? last_call[0] : null;
+  }
 
   describe('receiving a chatMsg', () => {
     test('register the corresponding log entry', () => {
-      let dataService = createDataChannelService(feedsService, logService);
       let data = JSON.stringify({
-        type: "chatMsg",
-        content: "Goodbye Molly!"
+        type: 'chatMsg',
+        content: 'Goodbye Molly!'
       });
 
       dataService.receiveMessage(data, 1);
-      var logged = logService.add.mock.calls;
-      var entry = logged[0][0];
+      var entry = last_log();
 
-      expect(logged.length).toBe(1);
-      expect(entry.type).toStrictEqual("chatMsg");
-      expect(entry.chatMsgText()).toStrictEqual("Goodbye Molly!");
-      expect(entry.content.feed).toBe(feed);
+      expect(entry.type).toStrictEqual('chatMsg');
+      expect(entry.chatMsgText()).toStrictEqual('Goodbye Molly!');
+      expect(entry.content.feed).toBe(publish_feed);
+    });
+  });
+
+  describe('receiving a muteRequest', () => {
+    describe('for the publisher feed', () => {
+      test('register the log entry and emits the event after receiving confirmation', () => {
+        let data = JSON.stringify({
+          type: 'muteRequest',
+          content: { target: 1 }
+        });
+
+        dataService.receiveMessage(data, 2);
+
+        var entry = last_log();
+        expect(entry.type).toStrictEqual('muteRequest');
+        expect(entry.content.target).toBe(publish_feed);
+
+        var ev = last_event();
+        expect(ev).toBeNull();
+
+        publish_feed.connection.confirmConfig();
+
+        ev = last_event();
+        expect(ev.type).toStrictEqual('muted');
+        expect(ev.data.by).toStrictEqual('request');
+      });
+    });
+
+    describe('for a subscriber feed', () => {
+      test('register the log entry', () => {
+        let data = JSON.stringify({
+          type: 'muteRequest',
+          content: { target: 2 }
+        });
+
+        dataService.receiveMessage(data, 1);
+
+        var entry = last_log();
+        expect(entry.type).toStrictEqual('muteRequest');
+        expect(entry.content.target).toBe(subscribe_feed);
+      });
     });
   });
 });

--- a/src/janus-api/log-service.js
+++ b/src/janus-api/log-service.js
@@ -9,13 +9,11 @@ export const createLogService = eventsService => {
   let entries = [];
   let that = {};
 
-  that.add = entry => {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        entries.push(entry);
-        eventsService.emitEvent({ type: 'log', entry });
-        resolve();
-      });
+  that.add = (entry) => {
+    return new Promise((resolve) => {
+      entries.push(entry);
+      eventsService.emitEvent({ type: 'log', entry });
+      resolve();
     });
   };
 

--- a/src/janus-api/models/connection-config.js
+++ b/src/janus-api/models/connection-config.js
@@ -66,21 +66,27 @@ export const createConnectionConfig = function(pluginHandle, wantedInit, jsep, o
    */
   that.confirm = function() {
     return new Promise(function(resolve, reject) {
-      setTimeout(function() {
-        if (requested === null) {
-          console.error("I haven't sent a config. Where does this confirmation come from?");
-          reject();
-        } else {
-          current = requested;
-          requested = null;
-          console.log("Connection configured", current);
-          if (okCallback) { okCallback(); }
-          if (differsFromWanted(current)) {
-            configure();
-          }
-          resolve();
+      if (requested === null) {
+        console.error(
+          
+          "I haven't sent a config. Where does this confirmation come from?"
+        
+        );
+        reject();
+      } else {
+        current = requested;
+        requested = null;
+        console.log('Connection configured', current);
+        if (okCallback) {
+         
+          okCallback();
+       
         }
-      });
+        if (differsFromWanted(current)) {
+          configure();
+        }
+        resolve();
+      }
     });
   };
 

--- a/src/janus-api/models/feed.js
+++ b/src/janus-api/models/feed.js
@@ -279,26 +279,23 @@ export const createFeedFactory = (
       that.connection.setConfig({
         values: config,
         ok: function() {
-          // TODO: is setTimeout needed?
-          window.setTimeout(function() {
-            if (type === 'audio' && enabled === false) {
-              speaking = false;
-            }
-            if (options.after) {
-              options.after();
-            }
-            // Send the new status to remote peers
-            dataChannelService.sendStatus(that, { exclude: 'picture' });
+          if (type === 'audio' && enabled === false) {
+            speaking = false;
+          }
+          if (options.after) {
+            options.after();
+          }
+          // Send the new status to remote peers
+          dataChannelService.sendStatus(that, { exclude: 'picture' });
 
-            // send 'channel' event with status (enabled or disabled)
-            eventsService.emitEvent({
-              type: 'channel',
-              data: {
-                channel: type,
-                status: enabled,
-                peerconnection: that.connection.pluginHandle.webrtcStuff.pc
-              }
-            });
+          // send 'channel' event with status (enabled or disabled)
+          eventsService.emitEvent({
+            type: 'channel',
+            data: {
+              channel: type,
+              status: enabled,
+              peerconnection: that.connection.pluginHandle.webrtcStuff.pc
+            }
           });
         }
       });


### PR DESCRIPTION
Adding the corresponding `emitEvent` for both kinds of mutes (triggered by the user and triggered by a peer request).

Note: prettier added A LOT of noise.