### PR TITLE
Emit events on muting

### DIFF
--- a/src/janus-api/action-service.js
+++ b/src/janus-api/action-service.js
@@ -134,8 +134,9 @@ export const createActionService = (
       // If we are muting the main feed (the only publisher that can be
       // actually muted) raise a signal
       if (type === 'audio' && feed.isPublisher) {
-        // TODO: dispatch an event?
-        //  callback = function() { $rootScope.$broadcast('muted.byUser'); };
+        callback = function() {
+          eventsService.emitEvent({ type: 'muted', data: { by: 'user' } });
+        };
       }
       feed.setEnabledChannel(type, false, { after: callback });
     } else {

--- a/src/janus-api/action-service.js
+++ b/src/janus-api/action-service.js
@@ -64,11 +64,8 @@ export const createActionService = (
     if (feed === null) {
       return;
     }
-    window.setTimeout(function() {
-      // TODO: is the timeout really needed?
-      feed.disconnect();
-      feedsService.destroy(feedId);
-    });
+    feed.disconnect();
+    feedsService.destroy(feedId);
     // Log the event
     var entry = createLogEntry('destroyFeed', { feed: feed });
     logService.add(entry);
@@ -79,11 +76,8 @@ export const createActionService = (
     if (feed === null) {
       return;
     }
-    window.setTimeout(function() {
-      // TODO: is the timeout really needed?
-      feed.disconnect();
-      feedsService.destroy(feedId);
-    });
+    feed.disconnect();
+    feedsService.destroy(feedId);
   };
 
   that.ignoreFeed = function(feedId) {

--- a/src/janus-api/log-service.js
+++ b/src/janus-api/log-service.js
@@ -11,11 +11,9 @@ export const createLogService = eventsService => {
 
   that.add = entry => {
     return new Promise(resolve => {
-      setTimeout(() => {
-        entries.push(entry);
-        eventsService.emitEvent({ type: 'log', entry });
-        resolve();
-      });
+      entries.push(entry);
+      eventsService.emitEvent({ type: 'log', entry });
+      resolve();
     });
   };
 

--- a/src/janus-api/models/connection-config.js
+++ b/src/janus-api/models/connection-config.js
@@ -66,21 +66,23 @@ export const createConnectionConfig = function(pluginHandle, wantedInit, jsep, o
    */
   that.confirm = function() {
     return new Promise(function(resolve, reject) {
-      setTimeout(function() {
-        if (requested === null) {
-          console.error("I haven't sent a config. Where does this confirmation come from?");
-          reject();
-        } else {
-          current = requested;
-          requested = null;
-          console.log("Connection configured", current);
-          if (okCallback) { okCallback(); }
-          if (differsFromWanted(current)) {
-            configure();
-          }
-          resolve();
+      if (requested === null) {
+        console.error(
+          "I haven't sent a config. Where does this confirmation come from?"
+        );
+        reject();
+      } else {
+        current = requested;
+        requested = null;
+        console.log('Connection configured', current);
+        if (okCallback) {
+          okCallback();
         }
-      });
+        if (differsFromWanted(current)) {
+          configure();
+        }
+        resolve();
+      }
     });
   };
 

--- a/src/janus-api/models/feed.js
+++ b/src/janus-api/models/feed.js
@@ -279,26 +279,23 @@ export const createFeedFactory = (
       that.connection.setConfig({
         values: config,
         ok: function() {
-          // TODO: is setTimeout needed?
-          window.setTimeout(function() {
-            if (type === 'audio' && enabled === false) {
-              speaking = false;
-            }
-            if (options.after) {
-              options.after();
-            }
-            // Send the new status to remote peers
-            dataChannelService.sendStatus(that, { exclude: 'picture' });
+          if (type === 'audio' && enabled === false) {
+            speaking = false;
+          }
+          if (options.after) {
+            options.after();
+          }
+          // Send the new status to remote peers
+          dataChannelService.sendStatus(that, { exclude: 'picture' });
 
-            // send 'channel' event with status (enabled or disabled)
-            eventsService.emitEvent({
-              type: 'channel',
-              data: {
-                channel: type,
-                status: enabled,
-                peerconnection: that.connection.pluginHandle.webrtcStuff.pc
-              }
-            });
+          // send 'channel' event with status (enabled or disabled)
+          eventsService.emitEvent({
+            type: 'channel',
+            data: {
+              channel: type,
+              status: enabled,
+              peerconnection: that.connection.pluginHandle.webrtcStuff.pc
+            }
           });
         }
       });


### PR DESCRIPTION
Adding the corresponding `emitEvent` for both kinds of mutes (triggered by the user and triggered by a peer request).

Note: When a new argument is added to a service or factory, our tools decide to run `prettier` on the whole block (i.e. on the whole file). Enjoy the noise on this PR. :wink: