### PR TITLE
[React] Fix audio/video initial state

### DIFF
--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -64,7 +64,7 @@ const reducer = function(state = initialState, action) {
   switch (type) {
     case PARTICIPANT_JOINED: {
       // TODO: check initial values for audio/video
-      const participant = { ...payload, audio: true, video: true, stream_timestamp: null };
+      const participant = { ...payload, stream_timestamp: null };
       return {
         ...state,
         [participant.id]: participant

--- a/src/state/ducks/participants.test.js
+++ b/src/state/ducks/participants.test.js
@@ -41,7 +41,7 @@ describe('reducer', () => {
 
     expect(reducer(initialState, action)).toEqual({
       ...initialState,
-      5678: { id: 5678, username: 'otherUser', audio: true, video: true, stream_timestamp: null }
+      5678: { id: 5678, username: 'otherUser', stream_timestamp: null }
     });
   });
 


### PR DESCRIPTION
Do not set initial value of audio/video in the redux's store.