### PR TITLE
[React] Fix autocomplete DOM property

### DIFF
--- a/src/components/Chat/MessageForm/MessageForm.js
+++ b/src/components/Chat/MessageForm/MessageForm.js
@@ -29,7 +29,7 @@ function MessageForm() {
       onSubmit={(event) => handleSubmit(event, dispatch, textInput)}>
       <input
         type="text"
-        autocomplete="off"
+        autoComplete="off"
         id="text"
         placeholder="Enter your message here"
         ref={textInput}


### PR DESCRIPTION
> Although it's a DOM property of an <input>, React complains about it
when not using camelCase notation.

Related to #288 