### PR TITLE
Add the missing videoToggle function to the Janus API

### DIFF
--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -76,6 +76,9 @@ export default (function() {
 
     that.roomService.toggleChannel('audio', feed);
   };
+  that.toggleVideo = () => {
+    that.roomService.toggleChannel('video');
+  };
 
   return that;
 })();


### PR DESCRIPTION
I messed up with Git stash. Here is the missing `toggleVideo` function.