### PR TITLE
Janus 0.8.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "bootstrap-sass-official": "3.3 <= 3.3.4",
     "angular-bootstrap": "~0.14.3",
     "angular": "~1.4.8",
-    "janus-gateway": "git://github.com/meetecho/janus-gateway.git#96b866904d76d4",
+    "janus-gateway": "git://github.com/meetecho/janus-gateway.git#v0.8.2",
     "angular-block-ui": "~0.2.0",
     "lodash": "~3.10.1",
     "ngEmbed": "git://github.com/ritz078/ng-embed.git#5b2fa818197838f",

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -4,7 +4,7 @@ var gulp = require('gulp');
 var estream = require('event-stream')
 
 var $ = require('gulp-load-plugins')({
-  pattern: ['gulp-*', 'main-bower-files', 'uglify-save-license', 'del']
+  pattern: ['gulp-*', 'main-bower-files', 'del']
 });
 
 module.exports = function(options) {
@@ -44,7 +44,7 @@ module.exports = function(options) {
       .pipe($.rev())
       .pipe(jsFilter)
       .pipe($.ngAnnotate())
-      .pipe($.uglify({ preserveComments: $.uglifySaveLicense })).on('error', options.errorHandler('Uglify'))
+      .pipe($.terser())
       .pipe(jsFilter.restore())
       .pipe(cssFilter)
       .pipe($.replace('../../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/', '../fonts/'))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-sass": "~2.1.0",
     "gulp-size": "~1.2.0",
     "gulp-sourcemaps": "~1.3.0",
-    "gulp-uglify": "~1.1.0",
+    "gulp-terser": "^1.2.0",
     "gulp-useref": "~1.1.0",
     "gulp-util": "~3.0.2",
     "gulp-webserver": "^0.9.1",
@@ -49,7 +49,6 @@
     "merge-stream": "~0.1.7",
     "protractor": "~1.7.0",
     "require-dir": "~0.1.0",
-    "uglify-save-license": "~0.4.1",
     "wiredep": "~2.2.0",
     "wrench": "~1.5.8"
   },

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -479,7 +479,7 @@
           });
           
           // Unpublish feed when screen sharing stops
-          stream.onended = function () {
+          stream.oninactive = function () {
             // emit 'screenshareStop' event
             EventsService.emitEvent({
               type: "screenshare",


### PR DESCRIPTION
* Updates janus-gateway dependency to version 0.8.2.
* Backports a [fix](https://github.com/jangouts/jangouts/commit/505dbd43f100ceca725084440d712a5a44b6e299) from the React branch.