### PR TITLE
[React] New button to reconnect to another participant

### DIFF
--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -12,6 +12,7 @@ import { Janus } from '../../vendor/janus';
 import MuteButton from '../MuteButton';
 import ToggleVideo from '../ToggleVideo';
 import StopScreenSharing from '../StopScreenSharing';
+import Reconnect from '../Reconnect';
 import { actionCreators as participantsActions } from '../../state/ducks/participants';
 
 import './Participant.css';
@@ -57,6 +58,7 @@ function Participant({ id, display, isPublisher, isLocalScreen, streamReady, foc
       {!isLocalScreen && <MuteButton participantId={id} />}
       {isPublisher && !isLocalScreen && <ToggleVideo video={video} />}
       {isPublisher && isLocalScreen && <StopScreenSharing id={id}/>}
+      {!isPublisher && <Reconnect participantId={id} />}
     </div>
   );
 }

--- a/src/components/Reconnect/Reconnect.css
+++ b/src/components/Reconnect/Reconnect.css
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */

--- a/src/components/Reconnect/Reconnect.js
+++ b/src/components/Reconnect/Reconnect.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React from 'react';
+import { actionCreators as participantsActions } from '../../state/ducks/participants';
+import { useDispatch } from 'react-redux';
+import { GoSync } from 'react-icons/go';
+
+function Reconnect({ participantId }) {
+  const dispatch = useDispatch();
+  const Icon = GoSync;
+  const label = 'Restart connection';
+
+  return (
+    <button
+      title={label}
+      aria-label={label}
+      onClick={() => dispatch(participantsActions.reconnect(participantId))}>
+      <Icon />
+    </button>
+  );
+}
+
+export default Reconnect;

--- a/src/components/Reconnect/Reconnect.test.js
+++ b/src/components/Reconnect/Reconnect.test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React from 'react';
+import Reconnect from './Reconnect';
+import { renderWithRedux } from '../../setupTests';
+
+const initialState = {
+  participants: {
+    1: { isPublisher: true },
+    2: { isPublisher: false }
+  }
+};
+it('renders without crashing', () => {
+  renderWithRedux(<Reconnect participantId={2} />);
+});

--- a/src/components/Reconnect/index.js
+++ b/src/components/Reconnect/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+export { default } from './Reconnect';

--- a/src/janus-api/action-service.js
+++ b/src/janus-api/action-service.js
@@ -88,14 +88,14 @@ export const createActionService = (
     logService.add(entry);
   };
 
-  that.stopIgnoringFeed = function(feedId, connection) {
+  that.reconnectFeed = function(feedId, connection) {
     var feed = feedsService.find(feedId);
     if (feed === null) {
       return;
     }
-    feed.stopIgnoring(connection);
+    feed.reconnect(connection);
     // Log the event
-    var entry = createLogEntry('stopIgnoringFeed', { feed: feed });
+    var entry = createLogEntry('reconnectFeed', { feed: feed });
     logService.add(entry);
   };
 

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -82,6 +82,7 @@ export default (function() {
   that.toggleVideo = () => {
     that.roomService.toggleChannel('video');
   };
+  that.reconnectFeed = (feedId) => that.roomService.reconnectFeed(feedId);
 
   return that;
 })();

--- a/src/janus-api/models/feed.js
+++ b/src/janus-api/models/feed.js
@@ -236,11 +236,13 @@ export const createFeedFactory = (dataChannelService, eventsService) => (attrs) 
   };
 
   /**
-   * Stops ignoring the feed
+   * Assigns a new connection to the feed, replacing the current one if there is
+   * one.
    *
    * @param {FeedConnection} connection - new connection to Janus
    */
-  that.stopIgnoring = function(connection) {
+  that.reconnect = function(connection) {
+    that.disconnect();
     that.isIgnored = false;
     that.connection = connection;
   };

--- a/src/janus-api/models/log-entry.js
+++ b/src/janus-api/models/log-entry.js
@@ -58,8 +58,8 @@ export const createLogEntry = (type, content) => {
     return 'You are ignoring ' + that.content.feed.display + ' now';
   };
 
-  that.stopIgnoringFeedText = function() {
-    return 'You are not longer ignoring ' + that.content.feed.display;
+  that.reconnectFeedText = function() {
+    return 'Connected again with ' + that.content.feed.display;
   };
 
   that.hasText = function() {

--- a/src/janus-api/models/log-entry.test.js
+++ b/src/janus-api/models/log-entry.test.js
@@ -51,7 +51,7 @@ describe('#text', () => {
   xdescribe('destroyFeedText');
   xdescribe('newRemoteFeedText');
   xdescribe('ignoreFeedText');
-  xdescribe('stopIgnoringFeedText');
+  xdescribe('reconnectFeedText');
 });
 
 xdescribe('#hasText');

--- a/src/janus-api/room-service.js
+++ b/src/janus-api/room-service.js
@@ -397,7 +397,7 @@ export const createRoomService = (
           // TODO: is the timeout needed?
           window.setTimeout(function() {
             if (feed) {
-              actionService.stopIgnoringFeed(id, connection);
+              actionService.reconnectFeed(id, connection);
             } else {
               actionService.remoteJoin(id, display, connection);
             }
@@ -571,13 +571,13 @@ export const createRoomService = (
     actionService.destroyFeed(feedId);
   }
 
-  function ignoreFeed(feedId) {
+  that.ignoreFeed = function(feedId) {
     actionService.ignoreFeed(feedId);
-  }
+  };
 
-  function stopIgnoringFeed(feedId) {
+  that.reconnectFeed = function(feedId) {
     that.subscribeToFeed(feedId);
-  }
+  };
 
   that.toggleChannel = function(type, feed) {
     actionService.toggleChannel(type, feed);

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -46,6 +46,12 @@ const toggleVideo = (id) => {
   };
 };
 
+const reconnect = (id) => {
+  return function() {
+    janusApi.reconnectFeed(id);
+  };
+};
+
 const updateStatus = (id, status) => ({
   type: PARTICIPANT_UPDATE_STATUS,
   payload: { id, status }
@@ -121,6 +127,7 @@ const actionCreators = {
   setStream,
   toggleAudio,
   toggleVideo,
+  reconnect,
   updateStatus,
   updateLocalStatus,
   participantSpeaking,

--- a/src/state/ducks/participants.test.js
+++ b/src/state/ducks/participants.test.js
@@ -196,4 +196,13 @@ describe('action creators', () => {
       expect(janusApi.toggleVideo).toHaveBeenCalled();
     });
   });
+
+  describe('#reconnect', () => {
+    it('returns a function that asks janus to reconnect to the feed', () => {
+      janusApi.reconnectFeed = jest.fn();
+      const f = actionCreators.reconnect(1234);
+      f();
+      expect(janusApi.reconnectFeed).toHaveBeenCalledWith(1234);
+    });
+  });
 });


### PR DESCRIPTION
This implements #291. As said in the original ticket, this is re-imagined as a "reconnect" button.

In the JanusApi, the `stopIgnoringFeed` function is changed into `reconnectFeed`. That new version works if the feed is being ignored (like before) but also works in other cases.