### PR TITLE
[React] Add PIN based autentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12327,6 +12327,12 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
+    "mutationobserver-shim": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+      "integrity": "sha512-gciOLNN8Vsf7YzcqRjKzlAJ6y7e+B86u7i3KXes0xfxx/nfLmozlW1Vn+Sc9x3tPIePFgc1AeIFhtRgkqTjzDQ==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14654,6 +14654,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.5.tgz",
       "integrity": "sha512-+DMR2k5c6BqMDSMF8hLH0vYKtKTeikiFW+fj0LClN+XZg4N9b8QUAdHC62CGWNLTi/gnuuemNcNcTFrCvK1f+A=="
     },
+    "react-hook-form": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.1.3.tgz",
+      "integrity": "sha512-6+6wSge72A2Y7WGqMke4afOz0uDJ3gOPSysmYKkjJszSbmw8X8at7tJPzifnZ+cwLDR88b4on/D+jfH5azWbIw=="
+    },
     "react-icons": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-config-prettier": "^6.10.0",
     "husky": "^2.7.0",
     "lint-staged": "^10.0.7",
+    "mutationobserver-shim": "^0.3.3",
     "prettier": "^1.19.1",
     "react-test-renderer": "^16.12.0",
     "redux-mock-store": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dompurify": "^2.0.8",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-hook-form": "^5.1.3",
     "react-icons": "^3.9.0",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -16,7 +16,7 @@ import './Login.css';
 function Login() {
   const room = useSelector((state) => state.room);
 
-  if (room.logedIn) {
+  if (room.loggedIn) {
     return <Redirect to={`/room/${room.roomId}?user=${room.username}`} />;
   }
 

--- a/src/components/Login/Login.test.js
+++ b/src/components/Login/Login.test.js
@@ -26,7 +26,7 @@ describe('logged in', () => {
         <Route exact path="/" component={Login} />
         <Route path="/room" component={Room} />
       </MemoryRouter>,
-      { initialState: { room: { logedIn: true } } }
+      { initialState: { room: { loggedIn: true } } }
     );
 
     const speaker = await findByTestId('chatbox');
@@ -42,7 +42,7 @@ describe('not logged in', () => {
           <Route exact path="/" component={Login} />
           <Route path="/room" component={Room} />
         </MemoryRouter>,
-        { initialState: { room: { logedIn: false } } }
+        { initialState: { room: { loggedIn: false } } }
       );
     });
 

--- a/src/components/LoginForm/LoginForm.js
+++ b/src/components/LoginForm/LoginForm.js
@@ -6,8 +6,9 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import janusApi from '../../janus-api';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { actionCreators as roomActions } from '../../state/ducks/room';
 import './LoginForm.css';
 
@@ -25,46 +26,30 @@ function roomOptions(rooms) {
   ));
 }
 
-/**
- * Handles the form submmission.
- *
- * @param {Object} event
- * @param {function} dispatch
- * @param {Object} userInput
- * @param {Object} roomSelector
- * @returns {undefined}
- */
-function handleSubmit(event, dispatch, userInput, roomSelector) {
-  event.preventDefault();
-
-  const username = userInput.current.value;
-  const roomId = roomSelector.current.value;
-
-  // TODO: validate data and give feedback
-  dispatch(roomActions.login(username, roomId));
+function onSubmit(dispatch) {
+  return function(data) {
+    dispatch(roomActions.login(data.username, data.room));
+  };
 }
 
 function LoginForm() {
-  const roomSelector = React.createRef();
-  const userInput = React.createRef();
   const dispatch = useDispatch();
   const [rooms, setRooms] = useState([]);
+  const { register, handleSubmit } = useForm();
 
   useEffect(() => {
     janusApi.getRooms().then((r) => setRooms(r));
   }, []);
 
   return (
-    <form
-      className="LoginForm"
-      onSubmit={(event) => handleSubmit(event, dispatch, userInput, roomSelector)}>
+    <form className="LoginForm" onSubmit={handleSubmit(onSubmit(dispatch))}>
       <div className="form-row">
         <label htmlFor="username">Username</label>
-        <input type="text" id="username" name="username" ref={userInput} />
+        <input type="text" id="username" name="username" ref={register} required />
       </div>
       <div className="form-row">
         <label htmlFor="room">Room</label>
-        <select id="room" name="room" ref={roomSelector}>
+        <select id="room" name="room" ref={register} required>
           {roomOptions(rooms)}
         </select>
       </div>

--- a/src/components/LoginForm/LoginForm.js
+++ b/src/components/LoginForm/LoginForm.js
@@ -51,6 +51,7 @@ function LoginForm() {
   const previousRoom = useSelector((state) => state.room);
   const { register, handleSubmit, reset, watch } = useForm();
   const selectedRoom = watch('room');
+  const { username: previousUsername, error } = previousRoom;
 
   useEffect(() => {
     janusApi.getRooms().then((rooms) => {
@@ -67,13 +68,14 @@ function LoginForm() {
 
   return (
     <form className="LoginForm" onSubmit={handleSubmit(onSubmit(dispatch))}>
+      {error && <span className="error">{error}</span>}
       <div className="form-row">
         <label htmlFor="username">Username</label>
         <input
           type="text"
           id="username"
           name="username"
-          defaultValue={previousRoom.username}
+          defaultValue={previousUsername}
           ref={register}
           autoComplete="username"
           required

--- a/src/components/LoginForm/LoginForm.js
+++ b/src/components/LoginForm/LoginForm.js
@@ -8,7 +8,7 @@
 import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import janusApi from '../../janus-api';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { actionCreators as roomActions } from '../../state/ducks/room';
 import './LoginForm.css';
 
@@ -26,33 +26,80 @@ function roomOptions(rooms) {
   ));
 }
 
+/**
+ * Determines whether the select room requires a PIN.
+ *
+ * @param {Array} rooms - available rooms
+ * @param {String,Integer} roomId - roomId
+ * @returns {Boolean}
+ */
+function pinRequired(rooms, roomId) {
+  const id = parseInt(roomId);
+  const room = rooms.find((r) => r.id === id);
+  return room && room.pinRequired;
+}
+
 function onSubmit(dispatch) {
   return function(data) {
-    dispatch(roomActions.login(data.username, data.room));
+    dispatch(roomActions.login(data.username, data.room, data.pin));
   };
 }
 
 function LoginForm() {
   const dispatch = useDispatch();
   const [rooms, setRooms] = useState([]);
-  const { register, handleSubmit } = useForm();
+  const previousRoom = useSelector((state) => state.room);
+  const { register, handleSubmit, reset, watch } = useForm();
+  const selectedRoom = watch('room');
 
   useEffect(() => {
-    janusApi.getRooms().then((r) => setRooms(r));
+    janusApi.getRooms().then((rooms) => {
+      setRooms(rooms);
+      let roomId;
+      if (previousRoom.roomId) {
+        roomId = previousRoom.roomId;
+      } else if (rooms.length > 0) {
+        roomId = rooms[0].id;
+      }
+      reset({ room: roomId });
+    });
   }, []);
 
   return (
     <form className="LoginForm" onSubmit={handleSubmit(onSubmit(dispatch))}>
       <div className="form-row">
         <label htmlFor="username">Username</label>
-        <input type="text" id="username" name="username" ref={register} required />
+        <input
+          type="text"
+          id="username"
+          name="username"
+          defaultValue={previousRoom.username}
+          ref={register}
+          autoComplete="username"
+          required
+        />
       </div>
+
       <div className="form-row">
         <label htmlFor="room">Room</label>
         <select id="room" name="room" ref={register} required>
           {roomOptions(rooms)}
         </select>
       </div>
+
+      {pinRequired(rooms, selectedRoom) && (
+        <div className="form-row">
+          <label htmlFor="pin">Pin</label>
+          <input
+            type="password"
+            id="pin"
+            name="pin"
+            ref={register}
+            autoComplete="current-password"
+            required
+          />
+        </div>
+      )}
       <div className="form-row">
         <input type="submit" value="Sign in" />
       </div>

--- a/src/components/LoginForm/LoginForm.test.js
+++ b/src/components/LoginForm/LoginForm.test.js
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
-import TestRenderer from 'react-test-renderer';
 import LoginForm from './LoginForm';
 import { renderWithRedux } from '../../setupTests';
 import { act, screen } from '@testing-library/react';

--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -29,7 +29,7 @@ function Room({ location }) {
   const { roomId } = useParams();
 
   useEffect(() => {
-    if (room.logedIn) return;
+    if (room.loggedIn) return;
     const params = new URLSearchParams(location.search);
     const username = params.get('user') || randomUsername();
     // TODO: get username from local storage

--- a/src/components/Room/Room.test.js
+++ b/src/components/Room/Room.test.js
@@ -29,14 +29,14 @@ Janus.attachMediaStream = jest.fn();
 
 describe('when the user is not logged in', () => {
   it('tries to log in taking room and username from the URL', () => {
-    const store = mockStore({ room: { logedIn: false }, participants: [], messages: [] });
+    const store = mockStore({ room: { loggedIn: false }, participants: [], messages: [] });
 
     renderWithRedux(<Room location={{ search: 'user=Jane' }} />, { store });
 
     expect(store.getActions()).toEqual([
       {
         type: 'jangouts/room/LOGIN',
-        payload: { roomId: 5678, username: 'Jane', logingIn: true }
+        payload: { roomId: 5678, username: 'Jane', loggingIn: true }
       }
     ]);
   });
@@ -44,7 +44,7 @@ describe('when the user is not logged in', () => {
 
 describe('when the user is logged in', () => {
   it('does not try to log in', () => {
-    const store = mockStore({ room: { logedIn: true }, participants: [], messages: [] });
+    const store = mockStore({ room: { loggedIn: true }, participants: [], messages: [] });
 
     renderWithRedux(<Room location={{ search: 'user=Jane' }} />, { store });
 

--- a/src/components/Room/Room.test.js
+++ b/src/components/Room/Room.test.js
@@ -35,8 +35,8 @@ describe('when the user is not logged in', () => {
 
     expect(store.getActions()).toEqual([
       {
-        type: 'jangouts/room/LOGIN',
-        payload: { roomId: 5678, username: 'Jane', loggingIn: true }
+        type: 'jangouts/room/LOGIN_REQUEST',
+        payload: { roomId: 5678, username: 'Jane' }
       }
     ]);
   });

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -62,9 +62,9 @@ export default (function() {
   };
 
   that.getRooms = () => that.roomService.getRooms();
-  that.enterRoom = (room, username) => {
+  that.enterRoom = (room, username, pin) => {
     that.roomService.setRoom(room);
-    return that.roomService.enter(username);
+    return that.roomService.enter(username, pin);
   };
   that.publishScreen = () => that.roomService.publishScreen('screen');
   that.unpublishFeed = (feedId) => that.roomService.unPublishFeed(feedId);

--- a/src/janus-api/models/room.js
+++ b/src/janus-api/models/room.js
@@ -16,9 +16,10 @@
  * @param {String} description Room description
  * @param {Integer} participants How many participants are in the room
  * @param {Integer} publishers Maximum quantity of publishers
+ * @param {Boolean} pinRequired Whether a PIN is required to access the room
  */
-export function createRoom(id, description, participants, publishers) {
-  return { id, description, participants, publishers };
+export function createRoom(id, description, participants, publishers, pinRequired) {
+  return { id, description, participants, publishers, pinRequired };
 }
 
 /**
@@ -28,7 +29,14 @@ export function createRoom(id, description, participants, publishers) {
  * @property {Integer} options.description Room description
  * @property {Integer} options.num_participants How many participants are in the room
  * @property {Integer} options.max_publishers Maximum quantity of publishers
+ * @property {Integer} options.pin_required Maximum quantity of publishers
  */
-export function createRoomFromJanus({ room, description, num_participants, max_publishers }) {
-  return createRoom(room, description, num_participants, max_publishers);
+export function createRoomFromJanus({
+  room,
+  description,
+  num_participants,
+  max_publishers,
+  pin_required
+}) {
+  return createRoom(room, description, num_participants, max_publishers, pin_required);
 }

--- a/src/janus-api/room-service.js
+++ b/src/janus-api/room-service.js
@@ -160,17 +160,18 @@ export const createRoomService = (
   };
 
   // Enter the room
-  that.enter = (username) => {
+  that.enter = (username, pin) => {
     return new Promise((resolve, reject) => {
       that.connect().then(function() {
-        that.doEnter(username);
+        that.doEnter(username, pin);
         resolve();
       });
     });
   };
 
-  that.doEnter = (username) => {
+  that.doEnter = (username, pin) => {
     var connection = null;
+    that.pin = pin;
 
     // adding room to EventsService
     eventsService.setRoom(that.room);
@@ -200,7 +201,7 @@ export const createRoomService = (
         // Step 1. Right after attaching to the plugin, we send a
         // request to join
         connection = createFeedConnectionFactory(pluginHandle, that.room.id, 'main');
-        connection.register(username); // TODO: get pin
+        connection.register(username, pin);
       },
       error: function(error) {
         console.error('Error attaching plugin... ' + error);
@@ -258,6 +259,7 @@ export const createRoomService = (
           });
           actionService.enterRoom(msg.id, username, connection);
           // Step 3. Establish WebRTC connection with the Janus server
+
           // Step 4a (parallel with 4b). Publish our feed on server
 
           if (joinUnmutedLimit !== undefined && joinUnmutedLimit !== null) {
@@ -318,6 +320,7 @@ export const createRoomService = (
 
   that.leave = function leave() {
     actionService.leaveRoom();
+    that.pin = null;
   };
 
   that.setRoom = function(room) {
@@ -372,7 +375,7 @@ export const createRoomService = (
           }
         });
         connection = createFeedConnectionFactory(pluginHandle, that.room.id, 'subscriber');
-        connection.listen(id, ''); // TODO: pin support
+        connection.listen(id, that.pin);
       },
       error: function(error) {
         console.error('  -- Error attaching plugin... ' + error);
@@ -480,7 +483,7 @@ export const createRoomService = (
           }
         });
         connection = createFeedConnectionFactory(pluginHandle, that.room.id, videoSource);
-        connection.register(display, ''); // TODO: pin
+        connection.register(display, that.pin);
         // TODO: ScreenShareService.setInProgress(true);
       },
       error: function(error) {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) [2020] SUSE Linux
-  *
+ *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
  */
@@ -8,6 +8,7 @@
 // react-testing-library renders your components to document.body,
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom/extend-expect';
+import 'mutationobserver-shim';
 
 import React from 'react';
 import { createStore } from 'redux';
@@ -21,6 +22,6 @@ export function renderWithRedux(
 ) {
   return {
     ...render(<Provider store={store}>{ui}</Provider>),
-    store,
-  }
+    store
+  };
 }

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -9,6 +9,7 @@ import janusApi from '../../janus-api';
 import history from '../../utils/history';
 
 const ROOM_LOGIN = 'jangouts/room/LOGIN';
+const ROOM_LOGIN_REQUEST = 'jangouts/room/LOGIN_REQUEST';
 const ROOM_LOGOUT = 'jangouts/room/LOGOUT';
 
 const login = (username, room) => {
@@ -29,13 +30,12 @@ const login = (username, room) => {
 };
 
 const loginRequest = ({ roomId, username }) => ({
-  type: ROOM_LOGIN,
-  payload: { roomId, username, loggingIn: true }
+  type: ROOM_LOGIN_REQUEST,
+  payload: { roomId, username }
 });
 
 const loginSuccess = ({ roomId, username }) => ({
-  type: ROOM_LOGIN,
-  payload: { roomId, username, loggedIn: true }
+  type: ROOM_LOGIN
 });
 
 const loginFailure = (error) => ({
@@ -61,20 +61,28 @@ const actionCreators = {
 
 const actionTypes = {
   ROOM_LOGIN,
+  ROOM_LOGIN_REQUEST,
   ROOM_LOGOUT
 };
 
-export const initialState = {};
+export const initialState = { loggedIn: false, loggingIn: false };
 
 const reducer = function(state = initialState, action) {
   const { type, payload } = action;
 
   switch (type) {
+    case ROOM_LOGIN_REQUEST: {
+      return { ...payload, loggingIn: true };
+    }
     case ROOM_LOGIN: {
-      return payload;
+      if (payload !== undefined && payload.error) {
+        return { ...state, loggingIn: false, loggedIn: false, error: payload.error };
+      } else {
+        return { ...state, loggingIn: false, loggedIn: true };
+      }
     }
     case ROOM_LOGOUT: {
-      return initialState;
+      return { ...state, loggedIn: false };
     }
     default:
       return state;

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -30,12 +30,12 @@ const login = (username, room) => {
 
 const loginRequest = ({ roomId, username }) => ({
   type: ROOM_LOGIN,
-  payload: { roomId, username, logingIn: true }
+  payload: { roomId, username, loggingIn: true }
 });
 
 const loginSuccess = ({ roomId, username }) => ({
   type: ROOM_LOGIN,
-  payload: { roomId, username, logedIn: true }
+  payload: { roomId, username, loggedIn: true }
 });
 
 const loginFailure = (error) => ({

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -12,14 +12,14 @@ const ROOM_LOGIN = 'jangouts/room/LOGIN';
 const ROOM_LOGIN_REQUEST = 'jangouts/room/LOGIN_REQUEST';
 const ROOM_LOGOUT = 'jangouts/room/LOGOUT';
 
-const login = (username, room) => {
+const login = (username, room, pin = undefined) => {
   return function(dispatch) {
     const roomId = parseInt(room);
 
-    dispatch(loginRequest({ roomId, username }));
+    dispatch(loginRequest({ roomId, username, pin }));
 
     janusApi
-      .enterRoom({ id: roomId }, username)
+      .enterRoom({ id: roomId }, username, pin)
       .then(() => {
         dispatch(loginSuccess({ roomId, username }));
       })

--- a/src/state/ducks/room.test.js
+++ b/src/state/ducks/room.test.js
@@ -9,7 +9,6 @@ import reducer, { actionTypes as types, actionCreators as actions } from './room
 
 const username = 'jangouts';
 const roomId = 5678;
-const room = { id: roomId, name: 'Misc' };
 
 describe('reducer', () => {
   const initialState = {};
@@ -22,18 +21,31 @@ describe('reducer', () => {
 
   it('handles ROOM_LOGIN', () => {
     const action = {
-      type: types.ROOM_LOGIN,
-      payload: { roomId, username: 'me' }
+      type: types.ROOM_LOGIN
     };
 
-    expect(reducer(initialState, action)).toEqual(action.payload);
+    expect(reducer({ roomId, username }, action)).toEqual({
+      roomId,
+      username,
+      loggingIn: false,
+      loggedIn: true
+    });
   });
 
   it('handles ROOM_LOGOUT', () => {
     const action = { type: types.ROOM_LOGOUT };
 
-    expect(reducer(initialState, action)).toEqual(initialState);
+    expect(reducer({ roomId, username }, action)).toEqual({ roomId, username, loggedIn: false });
   });
+});
+
+it('handles ROOM_LOGIN_REQUEST', () => {
+  const action = {
+    type: types.ROOM_LOGIN_REQUEST,
+    payload: { roomId, username }
+  };
+
+  expect(reducer({ roomId, username }, action)).toEqual({ roomId, username, loggingIn: true });
 });
 
 describe('action creators', () => {

--- a/src/state/ducks/root.js
+++ b/src/state/ducks/root.js
@@ -48,7 +48,8 @@ const rootReducer = (state, action) => {
   // the reference to the local `state` variable before delegating in
   // the appReducer.
   if (action.type === roomActionTypes.ROOM_LOGOUT) {
-    state = { config: state.config };
+    const { config, room } = state;
+    state = { config, room };
   }
 
   return appReducer(state, action);

--- a/src/state/ducks/root.test.js
+++ b/src/state/ducks/root.test.js
@@ -14,7 +14,8 @@ describe('reducer', () => {
       url: 'http://jangouts.io/'
     },
     room: {
-      id: 'fakeRoomState'
+      roomId: 'fakeRoom',
+      username: 'fakeUser'
     },
     participants: {
       1: 'fakeParticipant'
@@ -30,7 +31,7 @@ describe('reducer', () => {
         config: currentState.config,
         messages: [],
         participants: {},
-        room: {}
+        room: { ...currentState.room, loggedIn: false }
       });
     });
   });


### PR DESCRIPTION
This PR adds support for PIN-based authentication.

* Adopts [react-hook-form](https://react-hook-form.com/) in order to simplify the LoginForm component.
* Bring back PIN authentication to janusApi.
* It displays the PIN control when the room requires a PIN. I would prefer just disabling the control, but we might need to adjust the styles. So, for the time being...
* It keeps the username and the room when you logout.
* Adds [autocomplete](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute) attributes.
* Splits the `ROOM_LOGIN` into `ROOM_LOGIN_REQUEST` and `ROOM_LOGIN`.