### PR TITLE
Preliminary rendering of links, emojis and images in the chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3534,8 +3534,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -3546,7 +3545,6 @@
       "version": "16.9.19",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz",
       "integrity": "sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -6188,8 +6186,7 @@
     "csstype": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
-      "dev": true
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -6665,6 +6662,16 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "emojibase": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-4.0.1.tgz",
+      "integrity": "sha512-CGTYlkabmUky7sBibxfsbKxosuJEUfVg6Z6WP/XbnBpYbaJ4/oKeBZPCI7cf3R7A3GfZ/0KRjaxYWm/Kv4VJ8w=="
+    },
+    "emojibase-regex": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/emojibase-regex/-/emojibase-regex-4.0.1.tgz",
+      "integrity": "sha512-S42UHkFfz15i4NNz+wi9iMKFo+B6Kalc6PJLpYX0BUANViXw4vSyYZMFdBGRLduSabWHuEcTLZl9xOa2YP3eJw=="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -8905,6 +8912,35 @@
       "requires": {
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
+      }
+    },
+    "interweave": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/interweave/-/interweave-12.5.0.tgz",
+      "integrity": "sha512-R6PE+FkhexspBwBS9wa+w0ZHORsXpFgDoLTKt+kazZRZVlO9+b0bpOcimMQ77hY+UwcE3eppGqhsNUVi3EfQmQ==",
+      "requires": {
+        "@types/react": "*",
+        "escape-html": "^1.0.3",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "interweave-autolink": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/interweave-autolink/-/interweave-autolink-4.2.1.tgz",
+      "integrity": "sha512-ziSNh+zwScJ9ZLPBeMpKCqqCNbkhfqKKDof4+uU2onPTmWIWJpLqtR8tDSstT9UqLTm3O/z1rgXvnd5hXlol1g==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "interweave-emoji": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/interweave-emoji/-/interweave-emoji-5.3.1.tgz",
+      "integrity": "sha512-4IPdVMdtqLp0zYtJsy+LnqgrhM5pm+Dz/LMuqNADjA6NfQ4zCzEophb0qveIdm+GlsS1VPd1qsvFNZ14IQPjUg==",
+      "requires": {
+        "@types/react": "*",
+        "emojibase-regex": "^4.0.0",
+        "prop-types": "^15.7.2"
       }
     },
     "invariant": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "dependencies": {
     "dompurify": "^2.0.8",
+    "emojibase": "^4.0.1",
+    "interweave": "^12.5.0",
+    "interweave-autolink": "^4.2.1",
+    "interweave-emoji": "^5.3.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-hook-form": "^5.1.3",

--- a/src/components/Chat/Message/ImgMatcher.js
+++ b/src/components/Chat/Message/ImgMatcher.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React from 'react';
+import { Node } from 'interweave';
+import { UrlMatcher } from 'interweave-autolink';
+
+export default class ImgMatcher extends UrlMatcher {
+  replaceWith(children: ChildrenNode, props: UrlProps): Node {
+    return (
+      <span className="img-matcher">
+        {children}
+        <img src={props.url} />
+      </span>
+    );
+  }
+
+  asTag(): string {
+    return 'span';
+  }
+
+  match(string: string): MatchResponse<UrlMatch> | null {
+    const response = super.match(string);
+
+    if (response && response.urlParts.path.match(/\.(jpg|jpeg|png|gif)$/)) {
+      return response;
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/components/Chat/Message/Message.js
+++ b/src/components/Chat/Message/Message.js
@@ -6,6 +6,15 @@
  */
 
 import React from 'react';
+import BaseInterweave, { InterweaveProps } from 'interweave';
+import { useEmojiData, EmojiMatcher } from 'interweave-emoji';
+import { UrlMatcher } from 'interweave-autolink';
+import ImgMatcher from './ImgMatcher';
+
+const Interweave = (props: InterweaveProps) => {
+  const [emojis, source, manager] = useEmojiData({ compact: false });
+  return <BaseInterweave {...props} emojiSource={source} />;
+};
 
 const renderUsername = (feed) => {
   if (!feed) {
@@ -26,7 +35,20 @@ function Message({ type, content, text, timestamp }) {
         {content && renderUsername(content.feed)}
         <time dateTime={timestamp}>{time}</time>
       </div>
-      <div>{text()}</div>
+      <div>
+        <Interweave
+          content={text()}
+          matchers={[
+            new ImgMatcher('img'),
+            new UrlMatcher('url'),
+            new EmojiMatcher('emoji', {
+              convertEmoticon: true,
+              convertShortcode: true,
+              enlargeThreshold: 0
+            })
+          ]}
+        />
+      </div>
     </li>
   );
 }

--- a/src/components/Chat/MessagesList/MessagesList.js
+++ b/src/components/Chat/MessagesList/MessagesList.js
@@ -4,13 +4,22 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
  */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import Message from '../Message';
 
 function MessagesList() {
   const messages = useSelector((state) => state.messages);
+  const messagesEndRef = useRef(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  // FIXME: if the message contains an <img> tag, this can be triggered
+  // before the image is loaded.
+  useEffect(scrollToBottom);
 
   return (
     <div className="MessageList">
@@ -19,6 +28,7 @@ function MessagesList() {
           <Message key={index} {...m} />
         ))}
       </ul>
+      <div ref={messagesEndRef} />
     </div>
   );
 }


### PR DESCRIPTION
Initial work for #304 

Added Interweave, that provides a very nice mechanism to safely render the chat messages.

Activated interweave matchers to interpolate urls and emojis (supporting both emoticons and emoji shortcodes).

Created a new (pretty simplistic at this stage) matcher to display images inline.

![interweave1](https://user-images.githubusercontent.com/3638289/77829057-c4543800-711f-11ea-830a-d5dea88af7f2.png)
