### PR TITLE
[React] WIP: Add action to put the speaker in fullscreen

### DIFF
--- a/src/components/Room/Actions/ToggleFullscreen.js
+++ b/src/components/Room/Actions/ToggleFullscreen.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Maximize2 as Maximize, Minimize2 as Minimize } from 'react-feather';
+import { classNames } from '../../../utils/common';
+
+function ToggleFullscreen({elementRef, className}) {
+  const [usingFullscreen, setUsingFullscreen] = useState(false);
+
+  const Icon = usingFullscreen ? Minimize : Maximize;
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      elementRef.current.requestFullscreen()
+        .then(() => setUsingFullscreen(true))
+        .catch(err => {
+          alert(`Error attempting to enable full-screen mode: ${err.message} (${err.name})`);
+        });
+    } else {
+      document.exitFullscreen();
+    }
+  }
+
+  useEffect(() => {
+    elementRef.current.addEventListener('fullscreenchange', () => {
+      setUsingFullscreen(document.fullscreenElement)
+    });
+  })
+
+
+  return(
+    <button
+      title={usingFullscreen ? "Exit from fullscren mode" : "Fullscreen"}
+      onClick={() => toggleFullscreen()}
+    >
+      <Icon
+        className={classNames(
+          "p-1",
+          usingFullscreen ? "bg-white text-primary-dark" : "bg-gray-400 text-white",
+          "hover:bg-gray-600",
+          className
+        )}
+      />
+    </button>
+  );
+}
+
+export default ToggleFullscreen;

--- a/src/components/Room/Actions/ToggleFullscreen.test.js
+++ b/src/components/Room/Actions/ToggleFullscreen.test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React from 'react';
+import ToggleFullscreen from './ToggleFullscreen';
+import { render } from '@testing-library/react';
+
+const ref = {
+  current: {
+    requestFullscreen: jest.fn(),
+    addEventListener: jest.fn()
+  }
+};
+
+it('renders without crashing', () => {
+  render(<ToggleFullscreen elementRef={ref} />);
+});

--- a/src/components/Speaker/Speaker.js
+++ b/src/components/Speaker/Speaker.js
@@ -5,12 +5,14 @@
  * of the MIT license.  See the LICENSE.txt file for details.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectors } from '../../state/ducks/participants';
 import janusApi from '../../janus-api';
 import { Janus } from '../../vendor/janus';
 import { classNames } from '../../utils/common';
+
+import ToggleFullscreen from '../Room/Actions/ToggleFullscreen';
 
 function setVideo(id, video, forceUpdate) {
   const stream = janusApi.getFeedStream(id);
@@ -21,7 +23,8 @@ function setVideo(id, video, forceUpdate) {
 }
 
 function Speaker() {
-  const video = React.createRef();
+  const video = React.createRef(null);
+  const videoWrapper = React.createRef(null);
   const speaker = useSelector(
     (state) => selectors.focusedParticipant(state.participants),
     (a, b) => a.id === b.id && a.stream_timestamp === b.stream_timestamp
@@ -34,15 +37,23 @@ function Speaker() {
   });
 
   return (
-    <video
-      ref={video}
-      muted={isPublisher}
-      className={classNames(
-        'max-h-full w-full focus:outline-none',
-        isPublisher && !isLocalScreen && 'mirrored'
-      )}
-      autoPlay
-    />
+    <div ref={videoWrapper} className="relative inline-flex w-full h-full">
+      <video
+        ref={video}
+        muted={isPublisher}
+        className={classNames(
+          'max-h-full w-full focus:outline-none',
+          isPublisher && !isLocalScreen && 'mirrored'
+        )}
+        autoPlay
+      />
+      <ToggleFullscreen
+        elementRef={videoWrapper}
+        className={classNames(
+          "absolute top-0 right-0"
+        )}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Context

* Few days ago someone asked for such feature in the `#jangouts` IRC channel at the `freenode.net` server
* There is a similar PR open for `master` branch - https://github.com/jangouts/jangouts/pull/185

## Useful links

* https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API
* https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenchange_event

## TODO

- [ ] Unit tests
- [ ] Improve the icon/action placement
- [ ] use the notification system instead an alert?
- [ ] removeEventListener?
     > if so, let's use the useEffect clean up - https://reactjs.org/docs/hooks-effect.html#example-using-hooks-1

## Screenshot

![Screenshot_2020-04-28 Jangouts(2)](https://user-images.githubusercontent.com/1691872/80544904-f5878880-89a9-11ea-9e2f-e02ab66dd2bf.png)
