### PR TITLE
Chat: better filtering of rendering of log messages

### DIFF
--- a/src/components/Chat/Message/Message.js
+++ b/src/components/Chat/Message/Message.js
@@ -21,19 +21,30 @@ function Message({ type, content, text, timestamp, onRender }) {
   const datetime = new Date(timestamp);
   const time = `${datetime.getHours()}:${String(datetime.getMinutes()).padStart('2', 0)}`;
 
-  return (
-    <li className="rounded m-2 p-2 bg-white overflow-hidden overflow-x-auto shadow" data-testid="message">
-      <div className="flex justify-between">
-        <div className="mr-1 font-bold text-xs md:text-sm">
-          {content && renderUsername(content.feed)}
+  if (type === 'chatMsg')
+    return (
+      <li
+        className="rounded m-2 p-2 bg-white overflow-hidden overflow-x-auto shadow"
+        data-testid="message">
+        <div className="flex justify-between">
+          <div className="mr-1 font-bold text-xs md:text-sm">
+            {content && renderUsername(content.feed)}
+          </div>
+          <time className="font-mono text-xs text-primary" dateTime={timestamp}>
+            {time}
+          </time>
         </div>
-        <time className="font-mono text-xs text-primary" dateTime={timestamp}>
-          {time}
-        </time>
-      </div>
-      <div className="px-2">
-        <Interweave content={text()} onRender={onRender} />
-      </div>
+        <div className="px-2">
+          <Interweave content={text()} onRender={onRender} />
+        </div>
+      </li>
+    );
+
+  return (
+    <li
+      className="rounded m-2 p-1 bg-white overflow-hidden overflow-x-auto shadow"
+      data-testid="message">
+      <div className="px-2 italic text-xs md:text-sm">{text()}</div>
     </li>
   );
 }

--- a/src/components/Chat/MessagesList/MessagesList.js
+++ b/src/components/Chat/MessagesList/MessagesList.js
@@ -10,9 +10,16 @@ import { useSelector } from 'react-redux';
 import Message from '../Message';
 
 function MessagesList() {
-  const messages = useSelector((state) => state.messages);
   const wrapperRef = useRef(null);
   const messagesRef = useRef(null);
+
+  const filterMessages = (messages) => {
+    // Avoid the pointless initial stream of messages like "x has joined the room"
+    // when entering a room in which there are partitipants already. Even if that
+    // means filtering a bit too much in some cases.
+    const first = messages.findIndex((msg) => msg.type !== 'newRemoteFeed');
+    return first < 0 ? [] : messages.slice(first);
+  };
 
   const mustScroll = (message) => {
     // FIXME: instead of using this threshold, we could verify whether the
@@ -36,6 +43,8 @@ function MessagesList() {
   };
 
   useEffect(updateScroll);
+
+  const messages = filterMessages(useSelector((state) => state.messages));
 
   return (
     <div ref={wrapperRef} className="h-full overflow-y-auto">


### PR DESCRIPTION
Display the log messages ("John has joined the room", "Mike has muted you", etc.) in its own compact way.

Filter out all the "X has joined the room" messages that are displayed when entering an already populated room (is not them who have joined, but you).

![chat-log-messages](https://user-images.githubusercontent.com/3638289/80567168-e4179e00-89f4-11ea-8989-da04ae22ef5d.png)

As you can see in the screenshots, there are no messages about people leaving the room. That's because of #325 