### PR TITLE
Improve compatiblity with Janus including detection of lurkers

### DIFF
--- a/src/app/components/feed/buttons/jh-audio-button.directive.js
+++ b/src/app/components/feed/buttons/jh-audio-button.directive.js
@@ -47,17 +47,20 @@
 
       function showsEnable() {
         var feed = vm.feed;
-        return (feed && feed.isPublisher && !feed.isLocalScreen && !feed.getAudioEnabled());
+        if (!feed || !feed.isConnected()) { return false; }
+        return (feed.isPublisher && !feed.isLocalScreen && !feed.getAudioEnabled());
       }
 
       function showsDisable() {
         var feed = vm.feed;
-        return (feed && !feed.isIgnored && feed.getAudioEnabled());
+        if (!feed || !feed.isConnected()) { return false; }
+        return (!feed.isIgnored && feed.getAudioEnabled());
       }
 
       function showsAudioOff() {
         var feed = vm.feed;
-        return (feed && !feed.isPublisher && !feed.isIgnored && !feed.getAudioEnabled());
+        if (!feed || !feed.isConnected()) { return false; }
+        return (!feed.isPublisher && !feed.isIgnored && !feed.getAudioEnabled());
       }
 
       function isSpeaking() {

--- a/src/app/components/feed/buttons/jh-sticky-button.directive.js
+++ b/src/app/components/feed/buttons/jh-sticky-button.directive.js
@@ -38,7 +38,7 @@
       }
 
       function showsEnable() {
-        return (!vm.sticky && !vm.feed.isIgnored);
+        return (!vm.sticky && !vm.feed.isIgnored && vm.feed.isConnected());
       }
 
       function showsDisable() {

--- a/src/app/components/feed/feed-connection.factory.js
+++ b/src/app/components/feed/feed-connection.factory.js
@@ -57,7 +57,7 @@
       };
 
       this.listen = function(feedId, pin) {
-        var listen = { "request": "join", "room": roomId, "ptype": "listener", "feed": feedId, "pin": pin || "" };
+        var listen = { "request": "join", "room": roomId, "ptype": "subscriber", "feed": feedId, "pin": pin || "" };
         pluginHandle.send({"message": listen});
       };
 

--- a/src/app/components/feed/feeds.factory.js
+++ b/src/app/components/feed/feeds.factory.js
@@ -45,10 +45,12 @@
       var picture = null;
       var speaking = false;
       var silentSince = Date.now();
-      var videoRemoteEnabled = true;
-      var audioRemoteEnabled = true;
       var stream = null;
       var speakObserver = null;
+      // Note: these two attributes are only updated via setStatus with the information
+      // received from the remote peer
+      var videoRemoteEnabled = true;
+      var audioRemoteEnabled = true;
 
       /**
        * Checks if a given channel is enabled
@@ -166,6 +168,8 @@
 
       /**
        * Sets if audio is enabled for this feed. Works only for remote ones.
+       *
+       * See setStatus
        */
       this.setAudioEnabled = function(val) {
         audioRemoteEnabled = val;
@@ -180,6 +184,8 @@
 
       /**
        * Sets if video is enabled for this feed. Works only for remote ones.
+       *
+       * See setStatus
        */
       this.setVideoEnabled = function(val) {
         videoRemoteEnabled = val;

--- a/src/app/components/feed/feeds.factory.js
+++ b/src/app/components/feed/feeds.factory.js
@@ -239,6 +239,7 @@
           speakObserver.destroy();
         }
         this.connection = null;
+        stream = null;
       };
 
       /**
@@ -250,13 +251,21 @@
       };
 
       /**
-       * Stops ignoring the feed
+       * Associates a connection to the feed
        *
        * @param {FeedConnection} connection - new connection to Janus
        */
-      this.stopIgnoring = function(connection) {
+      this.setConnection = function(connection) {
         this.isIgnored = false;
         this.connection = connection;
+      };
+
+      /**
+       * Sets the ignoring flag
+       * @param {boolean} val - true if the user wants to ignore the feed data
+       */
+      this.setIsIgnored = function(val) {
+        this.isIgnored = val;
       };
 
       /**
@@ -435,6 +444,7 @@
        * Enables or disables the video of the connection to Janus
        */
       this.setVideoSubscription = function(value) {
+        if (this.connection === null) { return; }
         this.connection.setConfig({values: {video: value}});
       };
 

--- a/src/app/components/feed/jh-feed.directive.js
+++ b/src/app/components/feed/jh-feed.directive.js
@@ -78,7 +78,7 @@
       } else {
         feed.setVideoSubscription(jhConfig.videoThumbnails || vm.highlighted);
         scope.$watch(
-          function() { return jhConfig.videoThumbnails || vm.highlighted || !vm.feed.isSilent(); },
+          function() { return vm.feed.isConnected() && (jhConfig.videoThumbnails || vm.highlighted || !vm.feed.isSilent());  },
           function(video) { feed.setVideoSubscription(video); }
         );
       }

--- a/src/app/components/feed/jh-main-feed.directive.js
+++ b/src/app/components/feed/jh-main-feed.directive.js
@@ -27,10 +27,12 @@
 
     function jhMainFeedLink(scope, element) {
       scope.$watch('vm.feed.getStream()', function(newVal) {
+        var video = $('video', element)[0];
         if (newVal !== undefined && newVal !== null) {
-          var video = $('video', element)[0];
           video.muted = true;
           Janus.attachMediaStream(video, newVal);
+        } else {
+          video.src = null;
         }
       });
     }

--- a/src/app/components/room/action.service.js
+++ b/src/app/components/room/action.service.js
@@ -89,7 +89,6 @@
       if (feed === null) { return; }
       $timeout(function () {
         feed.disconnect();
-        FeedsService.destroy(feedId);
       });
     }
 

--- a/src/app/components/room/action.service.js
+++ b/src/app/components/room/action.service.js
@@ -18,6 +18,7 @@
     this.enterRoom = enterRoom;
     this.leaveRoom = leaveRoom;
     this.remoteJoin = remoteJoin;
+    this.connectToFeed = connectToFeed;
     this.destroyFeed = destroyFeed;
     this.unpublishFeed = unpublishFeed;
     this.ignoreFeed = ignoreFeed;
@@ -72,6 +73,17 @@
       LogService.add(entry);
     }
 
+    function connectToFeed(feedId, connection) {
+      var feed = FeedsService.find(feedId);
+      if (feed === null) { return; }
+
+      if (feed.isIgnored) {
+        this.stopIgnoringFeed(feedId);
+      }
+
+      feed.setConnection(connection);
+    }
+
     function destroyFeed(feedId) {
       var feed = FeedsService.find(feedId);
       if (feed === null) { return; }
@@ -101,10 +113,11 @@
       LogService.add(entry);
     }
 
-    function stopIgnoringFeed(feedId, connection) {
+    function stopIgnoringFeed(feedId) {
       var feed = FeedsService.find(feedId);
       if (feed === null) { return; }
-      feed.stopIgnoring(connection);
+
+      feed.setIsIgnored(false);
       // Log the event
       var entry = new LogEntry("stopIgnoringFeed", {feed: feed});
       LogService.add(entry);

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -381,7 +381,7 @@
           console.error("  -- Error attaching plugin... " + error);
         },
         onmessage: function(msg, jsep) {
-          console.log(" ::: Got a message (listener) :::");
+          console.log(" ::: Got a message (subscriber) :::");
           console.log(JSON.stringify(msg));
           var event = msg.videoroom;
           console.log("Event: " + event);

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -193,7 +193,7 @@
             // Step 4a (parallel with 4b). Publish our feed on server
 
             if (isPresent(jhConfig.joinUnmutedLimit)) {
-              startMuted = (msg.publishers instanceof Array) && msg.publishers.length >= jhConfig.joinUnmutedLimit;
+              startMuted = isArray(msg.publishers) && msg.publishers.length >= jhConfig.joinUnmutedLimit;
             }
 
             connection.publish({
@@ -202,7 +202,7 @@
             });
 
             // Step 5. Attach to existing feeds, if any
-            if ((msg.publishers instanceof Array) && msg.publishers.length > 0) {
+            if (isArray(msg.publishers)) {
               that.subscribeToFeeds(msg.publishers);
             }
             // The room has been destroyed
@@ -211,7 +211,7 @@
             $$rootScope.$broadcast('room.destroy');
           } else if (event === "event") {
             // Any new feed to attach to?
-            if ((msg.publishers instanceof Array) && msg.publishers.length > 0) {
+            if (isArray(msg.publishers)) {
               that.subscribeToFeeds(msg.publishers);
             // One of the publishers has gone away?
             } else if (isPresent(msg.leaving)) {
@@ -306,8 +306,11 @@
     }
 
     function subscribeToFeeds(list) {
+      if (list.length === 0) { return; }
+
       console.log("Got a list of available publishers/feeds:");
       console.log(list);
+
       for (var f = 0; f < list.length; f++) {
         var id = list[f].id;
         var display = list[f].display;
@@ -589,6 +592,13 @@
      */
     function isPresent(value) {
       return (value !== undefined && value !== null);
+    }
+
+    /**
+     * Check whether the given argument is an array.
+     */
+    function isArray(value) {
+      return (value instanceof Array);
     }
   }
 }());

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -203,7 +203,7 @@
 
             // Step 5. Attach to existing feeds, if any
             if ((msg.publishers instanceof Array) && msg.publishers.length > 0) {
-              that.subscribeToFeeds(msg.publishers, that.room.id);
+              that.subscribeToFeeds(msg.publishers);
             }
             // The room has been destroyed
           } else if (event === "destroyed") {
@@ -212,7 +212,7 @@
           } else if (event === "event") {
             // Any new feed to attach to?
             if ((msg.publishers instanceof Array) && msg.publishers.length > 0) {
-              that.subscribeToFeeds(msg.publishers, that.room.id);
+              that.subscribeToFeeds(msg.publishers);
             // One of the publishers has gone away?
             } else if (isPresent(msg.leaving)) {
               var leaving = msg.leaving;

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -192,7 +192,7 @@
             // Step 3. Establish WebRTC connection with the Janus server
             // Step 4a (parallel with 4b). Publish our feed on server
 
-            if (jhConfig.joinUnmutedLimit !== undefined && jhConfig.joinUnmutedLimit !== null) {
+            if (isPresent(jhConfig.joinUnmutedLimit)) {
               startMuted = (msg.publishers instanceof Array) && msg.publishers.length >= jhConfig.joinUnmutedLimit;
             }
 
@@ -214,24 +214,24 @@
             if ((msg.publishers instanceof Array) && msg.publishers.length > 0) {
               that.subscribeToFeeds(msg.publishers, that.room.id);
             // One of the publishers has gone away?
-            } else if(msg.leaving !== undefined && msg.leaving !== null) {
+            } else if (isPresent(msg.leaving)) {
               var leaving = msg.leaving;
               ActionService.destroyFeed(leaving);
             // One of the publishers has unpublished?
-            } else if(msg.unpublished !== undefined && msg.unpublished !== null) {
+            } else if (isPresent(msg.unpublished)) {
               var unpublished = msg.unpublished;
               ActionService.unpublishFeed(unpublished);
             // Reply to a configure request
             } else if (msg.configured) {
               connection.confirmConfig();
             // The server reported an error
-            } else if(msg.error !== undefined && msg.error !== null) {
+            } else if (isPresent(msg.error)) {
               console.log("Error message from server" + msg.error);
               $$rootScope.$broadcast('room.error', msg.error);
             }
           }
 
-          if (jsep !== undefined && jsep !== null) {
+          if (isPresent(jsep)) {
             connection.handleRemoteJsep(jsep);
           }
         }
@@ -386,7 +386,7 @@
             console.log("What has just happened?!");
           }
 
-          if(jsep !== undefined && jsep !== null) {
+          if (isPresent(jsep)) {
             connection.subscribe(jsep);
           }
         },
@@ -519,7 +519,7 @@
           } else {
             console.log("Unexpected event for screen");
           }
-          if (jsep !== undefined && jsep !== null) {
+          if (isPresent(jsep)) {
             connection.handleRemoteJsep(jsep);
           }
         }
@@ -582,6 +582,13 @@
         DataChannelService.sendStatus(p, {exclude: "picture"});
         $timeout(function() { DataChannelService.sendStatus(p); }, 4000);
       });
+    }
+
+    /**
+     * Check whether the given argument has a value.
+     */
+    function isPresent(value) {
+      return (value !== undefined && value !== null);
     }
   }
 }());

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -213,19 +213,23 @@
             // Any new feed to attach to?
             if (isArray(msg.publishers)) {
               that.subscribeToFeeds(msg.publishers);
+            }
             // One of the publishers has gone away?
-            } else if (isPresent(msg.leaving)) {
+            if (isPresent(msg.leaving)) {
               var leaving = msg.leaving;
               ActionService.destroyFeed(leaving);
+            }
             // One of the publishers has unpublished?
-            } else if (isPresent(msg.unpublished)) {
+            if (isPresent(msg.unpublished)) {
               var unpublished = msg.unpublished;
               ActionService.unpublishFeed(unpublished);
+            }
             // Reply to a configure request
-            } else if (msg.configured) {
+            if (msg.configured) {
               connection.confirmConfig();
+            }
             // The server reported an error
-            } else if (isPresent(msg.error)) {
+            if (isPresent(msg.error)) {
               console.log("Error message from server" + msg.error);
               $$rootScope.$broadcast('room.error', msg.error);
             }


### PR DESCRIPTION
Apart from some code readability enhancements and a bit of inline documentation, this pull request includes two important improvements in the compatibility with modern versions of Janus Gateway:

- Proper management and logging of users leaving a room. That fixes #325 
- Support for rooms configured with `notify_joining`, with prevent users from lurking the conversation without being noticed. Now everyone on the room (including those that are not publishing any audio/video stream) is displayed in the participants roster, if the room is configured to notify such participants. This fixes #310 and #158 