### PR TITLE
Final touches for 0.5.0

### DIFF
--- a/src/app/components/feed/feed-connection.factory.js
+++ b/src/app/components/feed/feed-connection.factory.js
@@ -56,8 +56,11 @@
         pluginHandle.send({"message": register});
       };
 
-      this.listen = function(feedId, pin) {
-        var listen = { "request": "join", "room": roomId, "ptype": "subscriber", "feed": feedId, "pin": pin || "" };
+      this.listen = function(feedId, pin, privateId) {
+        var listen = {
+          "request": "join", "room": roomId, "ptype": "subscriber", "feed": feedId,
+          "pin": pin || "", "private_id": privateId
+        };
         pluginHandle.send({"message": listen});
       };
 

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -81,6 +81,7 @@
         Janus.init({debug: jhConfig.janusDebug});
         that.janus = new Janus({
           server: that.server,
+          withCredentials: jhConfig.janusWithCredentials,
           success: function() {
             deferred.resolve();
           },

--- a/src/app/components/room/room.service.js
+++ b/src/app/components/room/room.service.js
@@ -189,6 +189,7 @@
                 status: "joined"
               }
             });
+            UserService.setPrivateId(msg.private_id);
             ActionService.enterRoom(msg.id, username, connection);
             // Step 3. Establish WebRTC connection with the Janus server
             // Step 4a (parallel with 4b). Publish our feed on server
@@ -375,7 +376,7 @@
             }
           });
           connection = new FeedConnection(pluginHandle, that.room.id, "subscriber");
-          connection.listen(id, UserService.getPin());
+          connection.listen(id, UserService.getPin(), UserService.getPrivateId());
         },
         error: function(error) {
           console.error("  -- Error attaching plugin... " + error);

--- a/src/app/components/user/user.service.js
+++ b/src/app/components/user/user.service.js
@@ -113,5 +113,25 @@
     this.setPin = function(value) {
       this.enteredPin = value;
     };
+
+    // Private id used for the communication with Janus
+    this.privateId = null;
+    /*
+     * Private identifier used by Janus Gateway to identify the participant and
+     * to correlate subscriber feeds to the main publisher feed.
+     *
+     * @returns string The id as a string, null if it's not set yet
+     */
+    this.getPrivateId = function() {
+      return this.privateId;
+    };
+
+    /*
+     * Set the private identifier used to identify the participant.
+     * @param   {string} val The id to use from now on
+     */
+    this.setPrivateId = function(value) {
+      this.privateId = value;
+    };
   }
 })();

--- a/src/app/config.provider.js
+++ b/src/app/config.provider.js
@@ -4,13 +4,14 @@
   angular.module("janusHangouts.config", [])
     .provider('jhConfig', function () {
       var config = {
-        "janusServer"     : null,
-        "janusServerSSL"  : null,
-        "janusDebug"      : false,
-        "httpsAvailable"  : true,
-        "httpsUrl"        : null,
-        "videoThumbnails" : true,
-        "joinUnmutedLimit": 3,
+        "janusServer"         : null,
+        "janusServerSSL"      : null,
+        "janusDebug"          : false,
+        "janusWithCredentials": true,
+        "httpsAvailable"      : true,
+        "httpsUrl"            : null,
+        "videoThumbnails"     : true,
+        "joinUnmutedLimit"    : 3,
       };
 
       return {

--- a/src/config.json.sample
+++ b/src/config.json.sample
@@ -2,6 +2,7 @@
   "janusServer": null,
   "janusServerSSL": null,
   "janusDebug": false,
+  "janusWithCredentials": true,
   "httpsAvailable": true,
   "httpsUrl": null,
   "videoThumbnails": true,


### PR DESCRIPTION
This pull request includes the last fixes I wanted to implement before releasing the first lurkers-free version of Jangouts. It's organized into independent commits:

### Provide private_id when subscribing to feeds

Janus Gateway provides a mechanism to correlate subscriber feeds (the mechanism used to consume webRTC streams) to publisher feeds (the mechanism used to join a room). A good Janus citizen should specify the private_if of a valid and active publisher every time it wants to establish a new subscriber feed.

If the room is configured with `require_pvtid`, providing such id becomes mandatory. Combining that setting with `notify_joining` is a good recipe to secure Janus rooms against anonymous lurkers.

Jangouts was already compatible with `notify_joining` (see #337) and now will also honor the private id, making it compatible with `require_pvtid` as well.

### Pass the `withCredentials` argument to Janus

@AdamMajer reported that it was not possible to deploy Jangouts using authentication on the Apache side. Using basic or digest authentication was interfering with the requests to the Janus Gateway server.

Now Jangouts provides the `withCredentials` argument to Janus, which should set the corresponding property of XHR requests. That should make the server authentication work without breaking anything else.

A configuration parameter `janusWithCredentials` was introduced to disable that behavior (it is true by default) in case it turns out to be a problem for some deploy.