### PR TITLE
Set the chat scroll at bottom after mounting it

### DIFF
--- a/src/components/Chat/MessagesList/MessagesList.js
+++ b/src/components/Chat/MessagesList/MessagesList.js
@@ -4,7 +4,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
  */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import Message from '../Message';
@@ -42,12 +42,22 @@ function MessagesList() {
     lastMsg.scrollIntoView({ behavior: 'smooth', block: 'end' });
   };
 
+  // Update the scroll after each render
   useEffect(updateScroll);
+
+  // Set the scroll at bottom just after mounting the component
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+
+    if (wrapper) {
+      wrapper.scrollTo({ top: wrapper.scrollHeight })
+    }
+  }, [])
 
   const messages = filterMessages(useSelector((state) => state.messages));
 
   return (
-    <div ref={wrapperRef} className="h-full overflow-y-auto">
+    <div ref={wrapperRef} className="h-full overflow-y-auto" role="log">
       <ul ref={messagesRef}>
         {messages.map((m, index) => (
           <Message key={index} onRender={updateScroll} {...m} />

--- a/src/components/Chat/MessagesList/MessagesList.test.js
+++ b/src/components/Chat/MessagesList/MessagesList.test.js
@@ -47,4 +47,14 @@ describe('when there are messages', () => {
 
     expect(getAllByTestId('message')).toHaveLength(2);
   });
+
+  it('sets the initial scroll position', () => {
+    const { getByRole } = renderWithRedux(<MessagesList id={1} display="User" />, {
+      initialState
+    });
+
+    const chatArea = getByRole('log');
+
+    expect(chatArea.scrollTo).toHaveBeenCalled()
+  });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -16,6 +16,10 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import reducers, { initialState } from './state/ducks';
 
+// Mock `scrollTo` function, used in the Chat component, since it isn't defined
+// in jsdom yet. Related to https://github.com/jsdom/jsdom/issues/1695
+Element.prototype.scrollTo = jest.fn();
+
 export function renderWithRedux(
   ui,
   { initialState, store = createStore(reducers, initialState) } = {}


### PR DESCRIPTION
## Problem

As reported in #332, when re-activating the chat the scroll is not _restored_ and the behavior of keeping it at bottom is lost because of this.

## Solution

Since we don't have a rich messages status (read/unread/last seen) yet, the solution is **to set the chat scroll at bottom after _re-mounting_ the component**.

In the future, if we implement the mentioned features, we can go further and restore the scroll position in the last seen message and even add a button for jumping directly to the end.

## Notes

* Although [React documentation prefers the standard `useEffect` and **recommends** start using it first](https://reactjs.org/docs/hooks-reference.html#uselayouteffect), this is IMHO a clear good candidate to use `useLayoutEffect` since it helps to avoid the flickering produced by the immediate change of the scroll position.

* I wanted to include more changes in this PR improving how auto-scroll is being done (and remove the [FIXME added there](https://github.com/jangouts/jangouts/blob/acc644fb3a02cf24f8007e828cdb2074fe14ed05/src/components/Chat/MessagesList/MessagesList.js#L25)). However, I discarded the idea because it's taking more time than I thought and I'd like to test some things first.