### PR TITLE
Make the Window Resize Mode more self-explanatory

### DIFF
--- a/src/app/components/videochat/buttons/jh-resize-mode-button.directive.js
+++ b/src/app/components/videochat/buttons/jh-resize-mode-button.directive.js
@@ -31,6 +31,7 @@
       vm.toggle = toggle;
       vm.reset = reset;
       vm.showsReset = showsReset;
+      vm.title = title;
 
       function toggle() {
         vm.toggleFn();
@@ -42,6 +43,10 @@
 
       function showsReset() {
         return vm.resizeModeOn;
+      }
+
+      function title() {
+        return vm.resizeModeOn ? "Save layout" : "Change screen layout";
       }
     }
   }

--- a/src/app/components/videochat/buttons/jh-resize-mode-button.html
+++ b/src/app/components/videochat/buttons/jh-resize-mode-button.html
@@ -9,6 +9,6 @@
   ng-class="{ 'btn-danger': vm.resizeModeOn }"
   class="btn"
   ng-click="vm.toggle()"
-  title="Window resize mode">
+  title="{{vm.title()}}">
   <span class="glyphicon glyphicon-pushpin"  aria-hidden="true"></span>
 </button>

--- a/src/app/components/videochat/jh-video-chat.directive.js
+++ b/src/app/components/videochat/jh-video-chat.directive.js
@@ -233,7 +233,14 @@
         vm.gridsterOpts.resizable.enabled = vm.windowResizeModeOn;
         vm.gridsterOpts.draggable.enabled = vm.windowResizeModeOn;
 
-        if (!vm.windowResizeModeOn) { storeGridster(); }
+        if (vm.windowResizeModeOn) {
+          Notifier.info(
+            "Drag to rearrange and resize the screen areas. " +
+            "Then click 'Save layout' to return to normal mode."
+          );
+        } else {
+          storeGridster();
+        }
       }
 
       function setDefaultLayout() {


### PR DESCRIPTION
We know the button to rearrange the page layout is as useful as hard to discover, so I decided to implement this small change to make it a bit more understandable.

The change in behavior should be obvious from the code changes. It adjusts the label of the button and adds the following help text:

![jangouts-resize](https://user-images.githubusercontent.com/3638289/83362844-d14a0d80-a394-11ea-9538-dfc169e6b8cd.png)
