### PR TITLE
Notify speaking while muted

### DIFF
--- a/src/components/Notifications/Notifications.test.js
+++ b/src/components/Notifications/Notifications.test.js
@@ -13,7 +13,7 @@ import Notifications from './Notifications';
 const notification1 = createNotification('You have been muted.');
 const notification2 = createNotification('Nobody is listening!');
 const initialState = {
-  notifications: { notifications: [notification1, notification2], blacklist: [] }
+  notifications: { notifications: [notification1, notification2], blocklist: [] }
 };
 
 it('renders without crashing', () => {

--- a/src/janus-api/models/feed.js
+++ b/src/janus-api/models/feed.js
@@ -315,6 +315,10 @@ export const createFeedFactory = (dataChannelService, eventsService) => (attrs) 
    * remote peers if needed.
    */
   function updateLocalSpeaking(val) {
+    eventsService.emitEvent({
+      type: 'participantSpeaking',
+      data: { feedId: that.id, speaking: val }
+    });
     if (that.isEnabled('audio') === false) {
       val = false;
     }

--- a/src/state/ducks/notifications.js
+++ b/src/state/ducks/notifications.js
@@ -12,7 +12,7 @@ import { fromEvent as notificationFromEvent } from '../../utils/notifications';
 
 const NOTIFICATION_SHOW = 'jangouts/notification/SHOW';
 const NOTIFICATION_CLOSE = 'jangouts/notification/CLOSE';
-const NOTIFICATION_BLACKLIST = 'jangouts/notification/BLACKLIST';
+const NOTIFICATION_BLOCK = 'jangouts/notification/BLOCK';
 const DEFAULT_TIMEOUT = 5000;
 
 /**
@@ -50,8 +50,8 @@ const close = (id) => ({
   payload: { id }
 });
 
-const blacklist = (type) => ({
-  type: NOTIFICATION_BLACKLIST,
+const block = (type) => ({
+  type: NOTIFICATION_BLOCK,
   payload: { type }
 });
 
@@ -64,23 +64,23 @@ const actionCreators = {
   notifyEvent,
   show,
   close,
-  blacklist,
+  block,
   dispatchAction
 };
 
 const actionTypes = {
   NOTIFICATION_SHOW,
   NOTIFICATION_CLOSE,
-  NOTIFICATION_BLACKLIST
+  NOTIFICATION_BLOCK
 };
 
-const initialState = { notifications: [], blacklist: [] }
+const initialState = { notifications: [], blocklist: [] }
 
 const reducer = function(state = initialState, action) {
   switch (action.type) {
     case NOTIFICATION_SHOW: {
       const { notification } = action.payload;
-      if (state.blacklist.includes(notification.type)) {
+      if (state.blocklist.includes(notification.type)) {
         return state;
       }
       return {...state, notifications: [...state.notifications, notification] };
@@ -90,9 +90,9 @@ const reducer = function(state = initialState, action) {
       const notifications = state.notifications.filter((n) => n.id !== id);
       return {...state, notifications };
     }
-    case NOTIFICATION_BLACKLIST: {
+    case NOTIFICATION_BLOCK: {
       const { type } = action.payload;
-      return {...state, blacklist: [...state.blacklist, type]}
+      return {...state, blocklist: [...state.blocklist, type]}
     }
 
     default: {

--- a/src/state/ducks/notifications.js
+++ b/src/state/ducks/notifications.js
@@ -13,6 +13,7 @@ import { fromEvent as notificationFromEvent } from '../../utils/notifications';
 const NOTIFICATION_SHOW = 'jangouts/notification/SHOW';
 const NOTIFICATION_CLOSE = 'jangouts/notification/CLOSE';
 const NOTIFICATION_BLOCK = 'jangouts/notification/BLOCK';
+const NOTIFICATION_UNBLOCK = 'jangouts/notification/UNBLOCK';
 const DEFAULT_TIMEOUT = 5000;
 
 /**
@@ -29,35 +30,123 @@ const notifyEvent = (event, timeout) => (dispatch) => {
   }
 };
 
+const NOTIFY_DEFAULT_OPTIONS = {
+  timeout: DEFAULT_TIMEOUT,
+  block: false
+}
 /**
  * Action to display a notification (and hide it after the timeout)
  *
- * @param [UserNotification] notification - Notification
+ * @param [UserNotification] notification - Notification to show
  * @param [Number] timeout - Timeout (in miliseconds)
+ * @param [Number, bool] block - Block this type of notifications
+ *   When a number is given, it represents the time (in miliseconds)
+ *   until this kind of types are allowed again.
+ *   If it is set to 'true', they will block them indefinitely.
  */
-const notify = (notification, timeout = DEFAULT_TIMEOUT) => (dispatch) => {
-  dispatch(show(notification));
+const notify = (notification, options) => (dispatch, getState) => {
+  const { notifications: state } = getState();
+  if (isBlocked(notification.type, state)) return;
+
+  const { timeout, block } = {...NOTIFY_DEFAULT_OPTIONS, ...options};
+  const blockExpiration = (typeof(block) === "number") ? Date.now() + block : block;
+  dispatch(show(notification, blockExpiration));
   setTimeout(() => dispatch(close(notification.id)), timeout);
 };
 
-const show = (notification) => ({
+/**
+ * Action to display a notification
+ *
+ * @param [UserNotification] notification - Notification to show
+ * @param [Number, bool] block - Block this type of notifications
+ * @return [Object] Action to display the notification
+  */
+const show = (notification, block) => ({
   type: NOTIFICATION_SHOW,
-  payload: { notification }
+  payload: { notification, block }
 });
 
+/**
+ * Action to close a notification
+ *
+ * @param [Number] id - notification ID
+ * @return [Object] Action to close the notification
+ */
 const close = (id) => ({
   type: NOTIFICATION_CLOSE,
   payload: { id }
 });
 
+/**
+ * Action to block a notification type
+ *
+ * @param [String] type - notification type
+ * @return [Object] Action to block the given type of notifications
+ */
 const block = (type) => ({
   type: NOTIFICATION_BLOCK,
   payload: { type }
 });
 
+/**
+ * Action to unblock a notification type
+ *
+ * @param [String] type - notification type
+ * @return [Object] Action to unblock the given type of notifications
+ */
+const unblock = (type) => ({
+  type: NOTIFICATION_UNBLOCK,
+  payload: { type }
+});
+
+/**
+ * Action to dispatch a notification action
+ *
+ * @param [Number] id - related notification ID
+  * @param [Object] action - action to dispatch
+ */
 const dispatchAction = (id, action) => (dispatch) => {
   dispatch(action);
   dispatch(close(id))
+}
+
+/**
+ * Determines whether a notification type is blocked
+ *
+ * @param [String] type - notification type
+ * @param [Object] state - current state
+ * @return [boolean]
+ */
+const isBlocked = (type, state) => {
+  const block = state.blocklist[type] || false;
+  if (typeof(block) === "number") {
+    return block > Date.now();
+  }
+  return block;
+}
+
+/**
+ * Helper function to add a type to the blocklist
+ *
+ * @param [String] type - Notification type
+ * @param [Number, true] block - Block this type of notifications
+ * @param [Object] state - Original state
+ * @return [Object] state without the blocklist
+ */
+const addTypeToBlocklist = (type, block, state) => {
+  return {...state, blocklist: {...state.blocklist, [type]: block}};
+}
+
+/**
+ * Helper function to remove a type from the blocklist
+ *
+ * @param [String] type - Notification type
+ * @param [Object] state - Original state
+ * @return [Object] state without the blocklist
+ */
+const removeTypeFromBlocklist = (type, state) => {
+  const {[type]: _v, ...blocklist } = state.blocklist;
+  return {...state, blocklist};
 }
 
 const actionCreators = {
@@ -65,6 +154,7 @@ const actionCreators = {
   show,
   close,
   block,
+  unblock,
   dispatchAction
 };
 
@@ -74,25 +164,34 @@ const actionTypes = {
   NOTIFICATION_BLOCK
 };
 
-const initialState = { notifications: [], blocklist: [] }
+const initialState = { notifications: [], blocklist: {} }
 
 const reducer = function(state = initialState, action) {
   switch (action.type) {
     case NOTIFICATION_SHOW: {
-      const { notification } = action.payload;
-      if (state.blocklist.includes(notification.type)) {
-        return state;
+      const { notification, block } = action.payload;
+      const newState = {...state, notifications: [...state.notifications, notification] };
+      if (block) {
+        return addTypeToBlocklist(notification.type, block, newState);
+      } else {
+        return removeTypeFromBlocklist(notification.type, newState);
       }
-      return {...state, notifications: [...state.notifications, notification] };
     }
+
     case NOTIFICATION_CLOSE: {
       const { id } = action.payload;
       const notifications = state.notifications.filter((n) => n.id !== id);
       return {...state, notifications };
     }
+
     case NOTIFICATION_BLOCK: {
       const { type } = action.payload;
-      return {...state, blocklist: [...state.blocklist, type]}
+      return addTypeToBlocklist(type, true, state);
+    }
+
+    case NOTIFICATION_UNBLOCK: {
+      const { type } = action.payload;
+      return removeTypeFromBlocklist(type, state);
     }
 
     default: {

--- a/src/state/ducks/notifications.test.js
+++ b/src/state/ducks/notifications.test.js
@@ -22,9 +22,9 @@ describe('reducer', () => {
     expect(reducer(initialState, action)).toEqual({...initialState, notifications: [notification]});
   });
 
-  it('handles NOTIFICATION_SHOW when the notification is blacklisted', () => {
+  it('handles NOTIFICATION_SHOW when the notification is blocked', () => {
     const action = actionCreators.show(notification);
-    const state = {...initialState, blacklist: [notification.type]};
+    const state = {...initialState, blocklist: [notification.type]};
     expect(reducer(state, action)).toEqual(state);
   })
 
@@ -35,10 +35,10 @@ describe('reducer', () => {
     expect(reducedState.notifications).toEqual([other_notification]);
   });
 
-  it('handles NOTIFICATION_BLACKLIST', () => {
-    const action = actionCreators.blacklist(notification.type);
+  it('handles NOTIFICATION_BLOCK', () => {
+    const action = actionCreators.block(notification.type);
     const reducedState = reducer(initialState, action);
-    expect(reducedState.blacklist).toEqual([notification.type]);
+    expect(reducedState.blocklist).toEqual([notification.type]);
   });
 });
 
@@ -74,13 +74,13 @@ describe('action creators', () => {
     });
   });
 
-  describe('blacklist', () => {
+  describe('blocklist', () => {
     it('adds the message type to the black list', () => {
       const store = mockStore({ notifications: initialState });
-      store.dispatch(actionCreators.blacklist('muted'));
+      store.dispatch(actionCreators.block('muted'));
 
       expect(store.getActions()).toEqual([
-        expect.objectContaining({ type: 'jangouts/notification/BLACKLIST' })
+        expect.objectContaining({ type: 'jangouts/notification/BLOCK' })
       ]);
     });
   });

--- a/src/state/ducks/notifications.test.js
+++ b/src/state/ducks/notifications.test.js
@@ -22,11 +22,12 @@ describe('reducer', () => {
     expect(reducer(initialState, action)).toEqual({...initialState, notifications: [notification]});
   });
 
-  it('handles NOTIFICATION_SHOW when the notification is blocked', () => {
-    const action = actionCreators.show(notification);
-    const state = {...initialState, blocklist: [notification.type]};
-    expect(reducer(state, action)).toEqual(state);
-  })
+  it('handles NOTIFICATION_SHOW blocking further messages of the same type', () => {
+    const action = actionCreators.show(notification, true);
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState, notifications: [notification], blocklist: {[notification.type]: true}
+    });
+  });
 
   it('handles NOTIFICATION_CLOSE', () => {
     const action = actionCreators.close(notification.id);
@@ -36,9 +37,17 @@ describe('reducer', () => {
   });
 
   it('handles NOTIFICATION_BLOCK', () => {
-    const action = actionCreators.block(notification.type);
+    const type = 'muted';
+    const action = actionCreators.block(type);
     const reducedState = reducer(initialState, action);
-    expect(reducedState.blocklist).toEqual([notification.type]);
+    expect(reducedState.blocklist).toEqual({muted: true});
+  });
+
+  it('handles NOTIFICATION_UNBLOCK', () => {
+    const type = 'muted';
+    const action = actionCreators.unblock(type);
+    const reducedState = reducer({...initialState, blocklist: {[type]: true}}, action);
+    expect(reducedState.blocklist).toEqual({});
   });
 });
 
@@ -72,15 +81,34 @@ describe('action creators', () => {
         expect.objectContaining({ type: 'jangouts/notification/CLOSE' })
       ]);
     });
+
+    it('does not add the notification if the type is blocked', () => {
+      const store = mockStore(
+        { notifications: {...initialState, blocklist: { muted: true } } }
+      );
+      store.dispatch(actionCreators.notifyEvent(event));
+      expect(store.getActions()).toEqual([]);
+    })
   });
 
-  describe('blocklist', () => {
-    it('adds the message type to the black list', () => {
+  describe('block', () => {
+    it('adds the message type to the blocklist', () => {
       const store = mockStore({ notifications: initialState });
       store.dispatch(actionCreators.block('muted'));
 
       expect(store.getActions()).toEqual([
         expect.objectContaining({ type: 'jangouts/notification/BLOCK' })
+      ]);
+    });
+  });
+
+  describe('unblock', () => {
+    it('removes the message type from the blocklist', () => {
+      const store = mockStore({ notifications: {...initialState, blocklist: ['muted']} });
+      store.dispatch(actionCreators.unblock('muted'));
+
+      expect(store.getActions()).toEqual([
+        expect.objectContaining({ type: 'jangouts/notification/UNBLOCK' })
       ]);
     });
   });

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -39,6 +39,14 @@ const toggleAudio = (id) => {
   };
 };
 
+const unmute = () => (dispatch, getState) => {
+  const { id, audio } = localParticipant(getState().participants);
+  console.log("PARTICIPANT", id, audio);
+  if (!audio) {
+    dispatch(toggleAudio(id));
+  }
+}
+
 const toggleVideo = (id) => {
   return function() {
     janusApi.toggleVideo();
@@ -132,6 +140,7 @@ const actionCreators = {
   addParticipant,
   removeParticipant,
   setStream,
+  unmute,
   toggleAudio,
   toggleVideo,
   reconnect,
@@ -142,7 +151,7 @@ const actionCreators = {
   unsetFocus,
   autoSetFocus,
   startScreenSharing,
-  stopScreenSharing
+  stopScreenSharing,
 };
 
 const actionTypes = {

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -6,6 +6,7 @@
  */
 
 import janusApi from '../../janus-api';
+import { actionCreators as notificationActions } from './notifications';
 
 const PARTICIPANT_JOINED = 'jangouts/participant/JOIN';
 const PARTICIPANT_DETACHED = 'jangouts/participant/DETACH';
@@ -60,7 +61,16 @@ const updateLocalStatus = ({ audio, video }) => (dispatch, getState) => {
   dispatch(updateStatus(id, { audio, video }));
 }
 
-const participantSpeaking = (id, speaking) => (dispatch) => {
+const SPEAKING_NOTIF_INTERVAL = 60000;
+
+const participantSpeaking = (id, speaking) => (dispatch, getState) => {
+  const state = getState();
+  const { id: localId, audio } = localParticipant(state.participants);
+  if (id === localId && !audio && speaking) {
+    dispatch(
+      notificationActions.notifyEvent({ type: 'speaking' }, { block: SPEAKING_NOTIF_INTERVAL })
+    );
+  }
   dispatch(updateStatus(id, {speaking, speakingSince: Date.now()}));
 }
 

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -41,7 +41,6 @@ const toggleAudio = (id) => {
 
 const unmute = () => (dispatch, getState) => {
   const { id, audio } = localParticipant(getState().participants);
-  console.log("PARTICIPANT", id, audio);
   if (!audio) {
     dispatch(toggleAudio(id));
   }

--- a/src/state/ducks/participants.test.js
+++ b/src/state/ducks/participants.test.js
@@ -70,54 +70,37 @@ describe('reducer', () => {
   it('handles PARTICIPANT_UPDATE_STATUS', () => {
     const action = {
       type: actionTypes.PARTICIPANT_UPDATE_STATUS,
-      payload: { id: 1234, status: { audio: false, video: false } }
+      payload: { id: 1234, status: { audio: true, video: false } }
     };
 
     const state = reducer(initialState, action);
     const participant = state['1234'];
-    expect(participant['audio']).toEqual(false);
+    expect(participant['audio']).toEqual(true);
     expect(participant['video']).toEqual(false);
   });
 
-  it('handles PARTICIPANT_LOCAL_UPDATE_STATUS', () => {
-    const initialState = {
-      1234: { id: 1234, isPublisher: true, isLocalScreen: false },
-      5678: { id: 5678, isPublisher: false }
-    };
+  it('handles PARTICIPANT_UPDATE_STATUS: audio is false', () => {
     const action = {
-      type: actionTypes.PARTICIPANT_UPDATE_LOCAL_STATUS,
-      payload: { audio: false, video: false }
+      type: actionTypes.PARTICIPANT_UPDATE_STATUS,
+      payload: { id: 1234, status: { audio: false, speaking: true } }
     };
 
-    const state = reducer(initialState, action);
-    const participant = state['1234'];
-    expect(participant['audio']).toEqual(false);
-    expect(participant['video']).toEqual(false);
-    expect(participant['speaking']).toEqual(false);
+    const speakingState = {...initialState, 1234: {...participant, speaking: true }};
+    const state = reducer(speakingState, action);
+    const updatedParticipant = state['1234'];
+    expect(updatedParticipant).toMatchObject({audio: false, speaking: false, speakingSince: null});
   });
 
-  describe('handles PARTICIPANT_SPEAKING', () => {
-    it('sets the speakingChange timestamp when the user is speaking', () => {
-      const action = {
-        type: actionTypes.PARTICIPANT_SPEAKING,
-        payload: { id: 1234, speaking: true }
-      };
-      const state = reducer(initialState, action);
-      const participant = state['1234'];
-      expect(typeof participant.speakingChange).toBe('number');
-      expect(participant.speaking).toBe(true);
-    });
+  it('handles PARTICIPANT_UPDATE_STATUS: speaking is false', () => {
+    const action = {
+      type: actionTypes.PARTICIPANT_UPDATE_STATUS,
+      payload: { id: 1234, status: { audio: true, speaking: false } }
+    };
 
-    it('sets the speakingChange timestamp when the user is not speaking', () => {
-      const action = {
-        type: actionTypes.PARTICIPANT_SPEAKING,
-        payload: { id: 1234, speaking: false }
-      };
-      const state = reducer(initialState, action);
-      const participant = state['1234'];
-      expect(typeof participant.speakingChange).toBe('number');
-      expect(participant.speaking).toBe(false);
-    });
+    const speakingState = {...initialState, 1234: {...participant, audio: true, speaking: false }};
+    const state = reducer(speakingState, action);
+    const updatedParticipant = state['1234'];
+    expect(updatedParticipant).toMatchObject({audio: true, speaking: false, speakingSince: null});
   });
 
   describe('handles PARTICIPANT_SET_FOCUS', () => {
@@ -170,6 +153,15 @@ describe('action creators', () => {
       expect(action.payload).toEqual(participant.id);
     });
   });
+
+  describe('#updateStatus', () => {
+    it('creates an action to update the status', () => {
+      const action = actionCreators.updateStatus(1234, { video: true });
+      expect(action.type).toEqual(actionTypes.PARTICIPANT_UPDATE_STATUS);
+    });
+  });
+
+  describe.skip('#updateLocalStatus');
 
   describe('#setStream', () => {
     it('creates an action to set/update the participant stream', () => {

--- a/src/state/ducks/root.test.js
+++ b/src/state/ducks/root.test.js
@@ -31,7 +31,7 @@ describe('reducer', () => {
       expect(reducer(currentState, action)).toEqual({
         config: currentState.config,
         messages: [],
-        notifications: { notifications: [], blacklist: [] },
+        notifications: { notifications: [], blocklist: [] },
         participants: {},
         room: { ...currentState.room, loggedIn: false }
       });

--- a/src/state/ducks/root.test.js
+++ b/src/state/ducks/root.test.js
@@ -31,7 +31,7 @@ describe('reducer', () => {
       expect(reducer(currentState, action)).toEqual({
         config: currentState.config,
         messages: [],
-        notifications: { notifications: [], blocklist: [] },
+        notifications: { notifications: [], blocklist: {} },
         participants: {},
         room: { ...currentState.room, loggedIn: false }
       });

--- a/src/utils/events-handler.js
+++ b/src/utils/events-handler.js
@@ -55,9 +55,6 @@ export const createEventsHandler = (dispatchFn) => (event) => {
     },
     muted: (event) => {
       dispatchFn(actions.notifications.notifyEvent(event));
-    },
-    screenshare: (event) => {
-      dispatchFn(actions.notifications.notifyEvent(event));
     }
   };
 

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -11,7 +11,7 @@ import { actionCreators as messageActions } from '../state/ducks/notifications';
  * @param {number} id - Notification ID (unique)
  * @param {string} text - Notification text
  * @param {string} severity - Notification severity (SEVERITY_INFO, SEVERITY_WARN, SEVERITY_ERROR)
- * @param {string} type - Notification type. Used to classify notifications and blacklisting them.
+ * @param {string} type - Notification type. Used to classify notifications and block them.
  * @param {array}  actions - Possible actions related to the notification
  */
 export function UserNotification(id, text, type, severity, actions) {
@@ -49,7 +49,7 @@ export const fromEvent = ({type, data}) => {
  *
  * @param {string} text - Notification text
  * @param {string} severity - Notification severity (SEVERITY_INFO, SEVERITY_WARN, SEVERITY_ERROR)
- * @param {string} type - Notification type. Used to classify notifications and blacklisting them.
+ * @param {string} type - Notification type. Used to classify notifications and block them.
  */
 export const createNotification = (text, type, severity = SEVERITY_INFO, actions = []) => {
   return new UserNotification(nextId(), text, type, severity, actions);
@@ -83,7 +83,7 @@ const createMutedNotification= (data) => {
   if (data.cause == MUTED_USER) return null;
   const notification = createNotification(mutedText(data), MUTED_TYPE);
   notification.actions = [
-    new Action("Do not show again", messageActions.blacklist(MUTED_TYPE))
+    new Action("Do not show again", messageActions.block(MUTED_TYPE))
   ];
   return notification;
 }

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -6,6 +6,7 @@
  */
 
 import { actionCreators as messageActions } from '../state/ducks/notifications';
+import { actionCreators as participantActions } from '../state/ducks/participants';
 
 /**
  * @param {number} id - Notification ID (unique)
@@ -35,6 +36,10 @@ export function Action(label, toDispatch) {
 
 const createDoNotShowAgainAction = (type) => {
   return new Action("Do not show again", messageActions.block(type))
+}
+
+const createUnmuteAction = () => {
+  return new Action("Unmute", participantActions.unmute())
 }
 
 /**
@@ -87,6 +92,7 @@ const nextId = () => lastId++;
 const createMutedNotification= (data) => {
   if (data.cause === MUTED_USER) return null;
   const notification = createNotification(mutedText(data), MUTED_TYPE);
+  notification.actions.push(createUnmuteAction());
   if (data.cause !== MUTED_JOIN) {
     notification.actions.push(createDoNotShowAgainAction(MUTED_TYPE));
   }
@@ -129,6 +135,7 @@ const mutedText = (data) => {
 const createSpeakingNotification = (_data) => {
   const notification = createNotification("Trying to say something? You are muted.", SPEAKING_TYPE);
   notification.actions = [
+    createUnmuteAction(),
     createDoNotShowAgainAction(SPEAKING_TYPE)
   ];
   return notification;

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -66,42 +66,12 @@ export const SEVERITY_ERROR = 'error';
  * Notifications types
   */
 const MUTED_TYPE = "muted";
-const SCREENSHARE_TYPE = "screenshare";
 
 /**
  * Each notification has a unique ID (local to each client).
  */
 let lastId = 0;
 const nextId = () => lastId++;
-
-/**
- * Factory function to create screen sharing notifications.
- *
- * @param {object} data - Event data
- * @return {UserNotification} - User notification
- */
-const createScreenShareNotification = (data) => {
-  return createNotification(screenshareText(data), SCREENSHARE_TYPE);
-}
-
-const SCREENSHARE_STARTED = 'started';
-const SCREENSHARE_STOPPED = 'stopped';
-
-const screenshareText = (data) => {
-  switch (data.status) {
-    case SCREENSHARE_STARTED: {
-      return 'You started sharing your screen.';
-    }
-
-    case SCREENSHARE_STOPPED: {
-      return 'You stopped sharing your screen.';
-    }
-
-    default: {
-      return null;
-    }
-  }
-};
 
 /**
  * Factory function to create notifications about users being 'muted'.
@@ -146,6 +116,5 @@ const mutedText = (data) => {
 };
 
 const eventFactories = {
-  muted: createMutedNotification,
-  screenshare: createScreenShareNotification
+  muted: createMutedNotification
 };

--- a/src/utils/notifications.test.js
+++ b/src/utils/notifications.test.js
@@ -47,26 +47,6 @@ describe('fromEvent', () => {
     expect(notification).toBeNull();
   })
 
-  it('when the user started sharing the screen', () => {
-    const notification = fromEvent({
-      type: 'screenshare',
-      data: { status: 'started' }
-    });
-
-    expect(notification.text).toContain('You started sharing');
-    expect(notification.severity).toEqual(SEVERITY_INFO);
-  });
-
-  it('when the user stopped sharing the screen', () => {
-    const notification = fromEvent({
-      type: 'screenshare',
-      data: { status: 'stopped' }
-    });
-
-    expect(notification.text).toContain('You stopped sharing');
-    expect(notification.severity).toEqual(SEVERITY_INFO);
-  });
-
   it('when the event is unknown', () => {
     const notification = fromEvent({
       type: 'unknown'

--- a/src/utils/notifications.test.js
+++ b/src/utils/notifications.test.js
@@ -47,6 +47,15 @@ describe('fromEvent', () => {
     expect(notification).toBeNull();
   })
 
+  it('when the user speaks but is muted', () => {
+    const notification = fromEvent({
+      type: 'speaking'
+    });
+
+    expect(notification.text).toContain('You are muted');
+    expect(notification.severity).toEqual(SEVERITY_INFO);
+  });
+
   it('when the event is unknown', () => {
     const notification = fromEvent({
       type: 'unknown'


### PR DESCRIPTION
Adds a notification when the user is speaking but muted. The notification features two buttons:

* "Do not show again" button which allows blocking future "speaking but muted" notifications.
* "Unmute" which allows unmuting.

This notification implements a timeout and it will not pop-up again until 1 minute has passed.

![speaking-but-muted](https://user-images.githubusercontent.com/15836/84513166-f7d74500-acc0-11ea-9d5a-959b0bd8fe33.png)

## Notifications infrastructure

The list of blocked notifications has turned into an object which keeps each blocked time and its expiration time. If the expiration is set to `true`, the notification type is blocked indefinitely.

## TODO

I consider the current implementation as good enough and we can refine it in subsequent PRs. There are, at least, two things the I would like to improve:

* Placing of options in the pop-up.
* Resetting the "block" of this notification when the user unmute and mute again (unless the user clicked the 'Do not show again' link).
* Improve the internal representation of the blocklist (using something like a union type would be nice).