### PR TITLE
Unblock speaking notification

### DIFF
--- a/src/components/Notifications/Notification.js
+++ b/src/components/Notifications/Notification.js
@@ -11,7 +11,9 @@ import { actionCreators as actions } from '../../state/ducks/notifications';
 
 function notificationAction(label, fn) {
   return (
-    <button key={label} className="text-blue-600 font-bold mr-2" onClick={fn}>
+    <button key={label}
+            className="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
+            onClick={fn}>
       {label}
     </button>
   );
@@ -26,13 +28,13 @@ function Notification({ notification }) {
       role="alertdialog"
       className="w-1/3 xl:w-1/4 mb-2 p-3 text-sm text-gray-700 border-b-2 border-secondary bg-white shadow-lg"
     >
-      {text}
+      <p className="text-gray-700">{text}</p>
 
-      <div className="mt-2">
-        { notificationAction("Dismiss", () => dispatch(actions.close(id))) }
+      <div className="mt-2 flex justify-around">
         { notification.actions.map(({label, toDispatch}) => (
           notificationAction(label, () => dispatch(actions.dispatchAction(id, toDispatch)))
         ))}
+        { notificationAction("Close", () => dispatch(actions.close(id))) }
       </div>
     </div>
   );

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -46,7 +46,8 @@ const setStream = (feedId, stream) => {
 };
 
 const toggleAudio = (id) => {
-  return function() {
+  return function(dispatch) {
+    dispatch(notificationActions.unblock('speaking'));
     janusApi.toggleAudio(id);
   };
 };

--- a/src/state/ducks/participants.test.js
+++ b/src/state/ducks/participants.test.js
@@ -6,6 +6,7 @@
  */
 
 import reducer, { actionTypes, actionCreators } from './participants';
+import { actionCreators as notificationActions } from './notifications';
 import { actionTypes as msgActionTypes } from './messages';
 import janusApi from '../../janus-api';
 import configureMockStore from 'redux-mock-store';
@@ -195,11 +196,23 @@ describe('action creators', () => {
   });
 
   describe('#toggleAudio', () => {
+    const store = mockStore({});
+    beforeEach(() => { store.clearActions(); });
+
     it('returns a function that asks janus to toggle the audio', () => {
       janusApi.toggleAudio = jest.fn();
       const f = actionCreators.toggleAudio(1234);
-      f();
+      f(store.dispatch);
       expect(janusApi.toggleAudio).toHaveBeenCalledWith(1234);
+    });
+
+    it('unblocks "speaking while muted" notifications', () => {
+      janusApi.toggleAudio = jest.fn();
+      const f = actionCreators.toggleAudio(1234);
+      f(store.dispatch);
+
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(notificationActions.unblock('speaking'));
     });
   });
 


### PR DESCRIPTION
This PR implements two changes:

* The "speaking while muted" notification is unblocked after the user unmutes/mutes him/herself.
* Small improvements in notifications presentation.

![jangouts-popup](https://user-images.githubusercontent.com/15836/93622075-67518480-f9d4-11ea-8184-fe5d5379a085.png)
