### PR TITLE
[React] Thumbnail mode support

### DIFF
--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -34,6 +34,26 @@ function renderImage(id, picture) {
   }
 }
 
+function takePicture(source, canvas, dispatchFn) {
+  let videoHeight = source.videoHeight;
+  let context = canvas.getContext('2d');
+
+  // Nothing to do if the video has no dimensions yet
+  if (!videoHeight) {
+    return;
+  }
+
+  let width = canvas.parentNode.offsetWidth;
+  let height = (width * videoHeight) / source.videoWidth;
+
+  canvas.width = width;
+  canvas.height = height;
+  context.drawImage(source, 0, 0, width, height);
+
+  let thumbnail = canvas.toDataURL('image/jpeg');
+  dispatchFn(participantsActions.updateLocalPicture(thumbnail));
+}
+
 function Participant({
   id,
   username,
@@ -59,27 +79,9 @@ function Participant({
       return;
     }
 
-    let thumbnailSource = videoRef.current;
-    let thumbnailCanvas = canvasRef.current;
-    let thumbnailContext = thumbnailCanvas.getContext('2d');
-
+    takePicture(videoRef.current, canvasRef.current, dispatch);
     const interval = setInterval(() => {
-      let videoHeight = thumbnailSource.videoHeight;
-
-      // Nothing to do if the video has no dimensions yet
-      if (!videoHeight) {
-        return;
-      }
-
-      let width = thumbnailCanvas.parentNode.offsetWidth;
-      let height = (width * videoHeight) / thumbnailSource.videoWidth;
-
-      thumbnailCanvas.width = width;
-      thumbnailCanvas.height = height;
-      thumbnailContext.drawImage(thumbnailSource, 0, 0, width, height);
-
-      let thumbnailData = thumbnailCanvas.toDataURL('image/jpeg');
-      dispatch(participantsActions.updateLocalPicture(thumbnailData));
+      takePicture(videoRef.current, canvasRef.current, dispatch);
     }, 5000);
 
     return () => clearInterval(interval);

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import ParticipantActions from './ParticipantActions';
 import { actionCreators as participantsActions } from '../../state/ducks/participants';
 import { classNames, attachStream } from '../../utils/common';
@@ -49,6 +49,8 @@ function Participant({
   const videoRef = React.createRef();
   const cssClassName = `Participant ${focus === 'user' ? 'focus' : ''}`;
   const canvasRef = React.createRef();
+  const thumbnailMode = useSelector(s => !!s.room.thumbnailMode);
+  const showVideo = video && !thumbnailMode;
 
   useEffect(() => setVideo(id, videoRef.current), [streamReady]);
 
@@ -97,10 +99,10 @@ function Participant({
           ref={videoRef}
           muted={isPublisher}
           autoPlay
-          className={classNames(video || 'invisible', isPublisher && !isLocalScreen && 'mirrored')}
+          className={classNames(showVideo || 'invisible', isPublisher && !isLocalScreen && 'mirrored')}
           onClick={() => dispatch(toggleFocus(id, focus))}
         />
-        { !video && renderImage(id, picture) }
+        { !showVideo && renderImage(id, picture) }
       </div>
       <div className="flex items-center p-1 bg-gray-200">
         <ParticipantActions participantId={id} />

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -53,7 +53,7 @@ function Participant({
   useEffect(() => setVideo(id, videoRef.current), [streamReady]);
 
   useEffect(() => {
-    if (!isPublisher || !video) {
+    if (!isPublisher) {
       return;
     }
 
@@ -97,7 +97,7 @@ function Participant({
           ref={videoRef}
           muted={isPublisher}
           autoPlay
-          className={classNames(video || 'hidden', isPublisher && !isLocalScreen && 'mirrored')}
+          className={classNames(video || 'invisible', isPublisher && !isLocalScreen && 'mirrored')}
           onClick={() => dispatch(toggleFocus(id, focus))}
         />
         { !video && renderImage(id, picture) }

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -26,6 +26,14 @@ function toggleFocus(id, focus) {
   return focus === 'user' ? participantsActions.unsetFocus() : participantsActions.setFocus(id);
 }
 
+function renderImage(id, picture) {
+  if (picture) {
+    return <img alt={id} src={picture} className="mirrored" />
+  } else {
+    return <UserIcon className={classNames('w-4/6 h-auto m-auto text-secondary')} />
+  }
+}
+
 function Participant({
   id,
   username,
@@ -34,7 +42,8 @@ function Participant({
   streamReady,
   focus,
   speaking,
-  video
+  video,
+  picture
 }) {
   const dispatch = useDispatch();
   const videoRef = React.createRef();
@@ -91,7 +100,7 @@ function Participant({
           className={classNames(video || 'hidden', isPublisher && !isLocalScreen && 'mirrored')}
           onClick={() => dispatch(toggleFocus(id, focus))}
         />
-        <UserIcon className={classNames('w-4/6 h-auto m-auto text-secondary', video && 'hidden')} />
+        { !video && renderImage(id, picture) }
       </div>
       <div className="flex items-center p-1 bg-gray-200">
         <ParticipantActions participantId={id} />

--- a/src/components/Participants/Participants.js
+++ b/src/components/Participants/Participants.js
@@ -29,7 +29,8 @@ const Participants = () => {
           streamTimestamp,
           speaking,
           focus,
-          video
+          video,
+          picture
         } = participant;
 
         return (
@@ -43,6 +44,7 @@ const Participants = () => {
             speaking={speaking}
             focus={focus}
             video={video}
+            picture={picture}
           />
         );
       })}

--- a/src/components/Room/Actions/ToggleThumbnailMode.js
+++ b/src/components/Room/Actions/ToggleThumbnailMode.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+  *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Camera as CameraIcon, Film as FilmIcon } from 'react-feather';
+import { actionCreators as roomActions } from '../../../state/ducks/room';
+
+function ToggleThumbnailMode({className, iconStyle}) {
+  const dispatch = useDispatch();
+  const thumbnailMode = useSelector(state => state.room.thumbnailMode);
+  const label = thumbnailMode ? "Disable thumbnail mode" : "Enable thumbnail mode"
+
+  return (
+    <button
+      title={label}
+      aria-label={label}
+      className={className}
+      onClick={() => dispatch(roomActions.toggleThumbnailMode())}>
+      { thumbnailMode ? <CameraIcon/> : <FilmIcon/> }
+    </button>
+  )
+}
+
+export default ToggleThumbnailMode;

--- a/src/components/Room/Actions/ToggleThumbnailMode.test.js
+++ b/src/components/Room/Actions/ToggleThumbnailMode.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+  *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React from 'react';
+import ToggleThumbnailMode from './ToggleThumbnailMode';
+import { renderWithRedux } from '../../../setupTests';
+
+it('renders without crashing', () => {
+  renderWithRedux(<ToggleThumbnailMode />);
+});

--- a/src/components/Room/Actions/index.js
+++ b/src/components/Room/Actions/index.js
@@ -7,3 +7,4 @@
 
 export { default as LogOut } from './LogOut';
 export { default as ShareScreen } from './ShareScreen';
+export { default as ToggleThumbnailMode } from './ToggleThumbnailMode';

--- a/src/components/Room/RoomActions.js
+++ b/src/components/Room/RoomActions.js
@@ -6,11 +6,12 @@
  */
 
 import React from 'react';
-import { LogOut, ShareScreen } from './Actions';
+import { LogOut, ShareScreen, ToggleThumbnailMode } from './Actions';
 
 function RoomActions(props) {
   return (
     <>
+      <ToggleThumbnailMode {...props} />
       <ShareScreen {...props} />
       <LogOut {...props} />
     </>

--- a/src/janus-api/action-service.js
+++ b/src/janus-api/action-service.js
@@ -138,5 +138,20 @@ export const createActionService = (
     feedsService.remoteFeeds().forEach((f) => f.setVideoSubscription(false));
   };
 
+  /**
+   * Set and broadcast the picture for the main feed
+   * @param {String} data
+   */
+  that.updateLocalPicture = function(data) {
+    var feed = feedsService.findMain();
+
+    if (!feed) {
+      return;
+    }
+
+    feed.setPicture(data);
+    dataChannelService.sendStatus(feed);
+  };
+
   return that;
 };

--- a/src/janus-api/action-service.js
+++ b/src/janus-api/action-service.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) [2015-2019] SUSE Linux
+ * Copyright (c) [2015-2020] SUSE Linux
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -128,6 +128,14 @@ export const createActionService = (
     }
 
     feed.setEnabledChannel(type, boolval);
+  };
+
+  that.enableVideoSubscriptions = function() {
+    feedsService.remoteFeeds().forEach((f) => f.setVideoSubscription(true));
+  };
+
+  that.disableVideoSubscriptions = function() {
+    feedsService.remoteFeeds().forEach((f) => f.setVideoSubscription(false));
   };
 
   return that;

--- a/src/janus-api/action-service.test.js
+++ b/src/janus-api/action-service.test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) [2020] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import { createActionService } from './action-service';
+
+const localFeed = { setVideoSubscription: jest.fn() };
+const remoteFeed = { setVideoSubscription: jest.fn() };
+
+const feedsService = {
+  allFeeds: () => [localFeed, remoteFeed],
+  remoteFeeds: () => [remoteFeed]
+};
+
+const actionService = createActionService(feedsService);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('#enableVideoSubscriptions', () => {
+  test('sets the video subscription for all remote feeds', () => {
+    actionService.enableVideoSubscriptions();
+
+    expect(localFeed.setVideoSubscription).not.toHaveBeenCalled();
+    expect(remoteFeed.setVideoSubscription).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('#disableVideoSubscriptions', () => {
+  test('removes the video subscription for all remote feeds', () => {
+    actionService.disableVideoSubscriptions();
+
+    expect(localFeed.setVideoSubscription).not.toHaveBeenCalled();
+    expect(remoteFeed.setVideoSubscription).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/janus-api/feeds-service.js
+++ b/src/janus-api/feeds-service.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) [2015-2019] SUSE Linux
+ * Copyright (c) [2015-2020] SUSE Linux
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -112,6 +112,13 @@ export const createFeedsService = (eventsService) => {
    */
   that.localScreenFeeds = function() {
     return that.allFeeds().filter((f) => f.getLocalScreen());
+  };
+
+  /**
+   * @returns {Array<Feed>} all registered remote feeds
+   */
+  that.remoteFeeds = function() {
+    return that.allFeeds().filter((f) => !f.isPublisher);
   };
 
   /**

--- a/src/janus-api/feeds-service.test.js
+++ b/src/janus-api/feeds-service.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) [2015-2019] SUSE Linux
+ * Copyright (c) [2015-2020] SUSE Linux
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -158,6 +158,22 @@ describe('#publisherFeeds', () => {
     test('returns an empty array', () => {
       const feedsService = createFeedsService();
       expect(feedsService.publisherFeeds()).toStrictEqual([]);
+    });
+  });
+});
+
+describe('#remoteFeeds', () => {
+  test('returns an array containing remote feeds', () => {
+    const feedsService = createFeedsService(eventsService);
+    feedsService.add(firstFeed);
+    feedsService.add(secondFeed);
+    expect(feedsService.remoteFeeds()).toEqual(expect.arrayContaining([secondFeed]));
+  });
+
+  describe('when there are no feeds', () => {
+    test('returns an empty array', () => {
+      const feedsService = createFeedsService();
+      expect(feedsService.remoteFeeds()).toStrictEqual([]);
     });
   });
 });

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -84,6 +84,7 @@ export default (function() {
       that.actionService.disableVideoSubscriptions();
     }
   }
+  that.updateLocalPicture = (data) => that.actionService.updateLocalPicture(data);
 
   return that;
 })();

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -77,8 +77,13 @@ export default (function() {
     that.roomService.toggleChannel('video');
   };
   that.reconnectFeed = (feedId) => that.roomService.reconnectFeed(feedId);
-  that.enableThumbnailMode = () => that.actionService.disableVideoSubscriptions();
-  that.disableThumbnailMode = () => that.actionService.enableVideoSubscriptions();
+  that.setVideoSubscriptions = (enabled) => {
+    if (enabled) {
+      that.actionService.enableVideoSubscriptions();
+    } else {
+      that.actionService.disableVideoSubscriptions();
+    }
+  }
 
   return that;
 })();

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) [2015-2019] SUSE Linux
+ * Copyright (c) [2015-2020] SUSE Linux
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -77,6 +77,8 @@ export default (function() {
     that.roomService.toggleChannel('video');
   };
   that.reconnectFeed = (feedId) => that.roomService.reconnectFeed(feedId);
+  that.enableThumbnailMode = () => that.actionService.disableVideoSubscriptions();
+  that.disableThumbnailMode = () => that.actionService.enableVideoSubscriptions();
 
   return that;
 })();

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -79,6 +79,12 @@ const detachParticipant = (participantId) => ({
   payload: participantId
 });
 
+const updateLocalPicture = (data) => {
+  return function() {
+    janusApi.updateLocalPicture(data);
+  };
+};
+
 const updateStatus = (id, status) => ({
   type: PARTICIPANT_UPDATE_STATUS,
   payload: { id, status }
@@ -190,6 +196,7 @@ const actionCreators = {
   updateStatus,
   localSpeak,
   requestMute,
+  updateLocalPicture,
   setFocus,
   unsetFocus,
   autoSetFocus,

--- a/src/state/ducks/participants.js
+++ b/src/state/ducks/participants.js
@@ -80,8 +80,10 @@ const detachParticipant = (participantId) => ({
 });
 
 const updateLocalPicture = (data) => {
-  return function() {
+  return function(dispatch, getState) {
     janusApi.updateLocalPicture(data);
+    const { id } = localParticipant(getState().participants);
+    dispatch(updateStatus(id, { picture: data }));
   };
 };
 

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -91,7 +91,7 @@ const reducer = function(state = initialState, action) {
       if (payload !== undefined && payload.error) {
         return { ...state, loggingIn: false, loggedIn: false, error: payload.error };
       } else {
-        return { ...state, loggingIn: false, loggedIn: true };
+        return { ...state, loggingIn: false, loggedIn: true, thumbnailMode: false };
       }
     }
     case ROOM_LOGOUT: {

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) [2015-2019] SUSE Linux
+ * Copyright (c) [2015-2020] SUSE Linux
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -11,6 +11,7 @@ import history from '../../utils/history';
 const ROOM_LOGIN = 'jangouts/room/LOGIN';
 const ROOM_LOGIN_REQUEST = 'jangouts/room/LOGIN_REQUEST';
 const ROOM_LOGOUT = 'jangouts/room/LOGOUT';
+const ROOM_TOGGLE_THUMBNAIL_MODE = 'jangouts/room/TOGGLE_THUMBNAIL_MODE';
 
 const login = (username, room, pin = undefined) => {
   return function(dispatch) {
@@ -53,19 +54,31 @@ const logout = () => {
   };
 };
 
+const toggleThumbnailMode = () => {
+  return function(dispatch, getState) {
+    let { thumbnailMode } = getState().room;
+
+    thumbnailMode ? janusApi.disableThumbnailMode() : janusApi.enableThumbnailMode();
+
+    dispatch({ type: ROOM_TOGGLE_THUMBNAIL_MODE, payload: { thumbnailMode: !thumbnailMode } });
+  };
+};
+
 const actionCreators = {
   login,
   logout,
-  loginFailure
+  loginFailure,
+  toggleThumbnailMode
 };
 
 const actionTypes = {
   ROOM_LOGIN,
   ROOM_LOGIN_REQUEST,
   ROOM_LOGOUT
+  ROOM_TOGGLE_THUMBNAIL_MODE,
 };
 
-export const initialState = { loggedIn: false, loggingIn: false };
+export const initialState = { loggedIn: false, loggingIn: false, thumbnailMode: false };
 
 const reducer = function(state = initialState, action) {
   const { type, payload } = action;
@@ -83,6 +96,9 @@ const reducer = function(state = initialState, action) {
     }
     case ROOM_LOGOUT: {
       return { ...state, loggedIn: false };
+    }
+    case ROOM_TOGGLE_THUMBNAIL_MODE: {
+      return { ...state, ...payload };
     }
     default:
       return state;

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -58,7 +58,7 @@ const toggleThumbnailMode = () => {
   return function(dispatch, getState) {
     let { thumbnailMode } = getState().room;
 
-    thumbnailMode ? janusApi.disableThumbnailMode() : janusApi.enableThumbnailMode();
+    janusApi.setVideoSubscriptions(thumbnailMode);
 
     dispatch({ type: ROOM_TOGGLE_THUMBNAIL_MODE, payload: { thumbnailMode: !thumbnailMode } });
   };
@@ -74,8 +74,8 @@ const actionCreators = {
 const actionTypes = {
   ROOM_LOGIN,
   ROOM_LOGIN_REQUEST,
-  ROOM_LOGOUT
-  ROOM_TOGGLE_THUMBNAIL_MODE,
+  ROOM_LOGOUT,
+  ROOM_TOGGLE_THUMBNAIL_MODE
 };
 
 export const initialState = { loggedIn: false, loggingIn: false, thumbnailMode: false };

--- a/src/state/ducks/room.test.js
+++ b/src/state/ducks/room.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) [2015-2019] SUSE Linux
+ * Copyright (c) [2015-2020] SUSE Linux
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -11,7 +11,9 @@ const username = 'jangouts';
 const roomId = 5678;
 
 describe('reducer', () => {
-  const initialState = {};
+  const initialState = {
+    thumbnailMode: false
+  };
 
   it('does not handle unknown action', () => {
     const action = { type: 'UNKNOWN', payload: {} };
@@ -23,13 +25,28 @@ describe('reducer', () => {
     const action = {
       type: types.ROOM_LOGIN
     };
+    const nextState = {
+      ...initialState,
+      roomId,
+      username: 'me'
+    };
 
     expect(reducer({ roomId, username }, action)).toEqual({
       roomId,
       username,
       loggingIn: false,
       loggedIn: true
+      thumbnailMode: false,
     });
+  });
+
+  it('handles ROOM_LOGIN_REQUEST', () => {
+    const action = {
+      type: types.ROOM_LOGIN_REQUEST,
+      payload: { roomId, username }
+    };
+
+    expect(reducer({ roomId, username }, action)).toEqual({ roomId, username, loggingIn: true });
   });
 
   it('handles ROOM_LOGOUT', () => {
@@ -37,16 +54,17 @@ describe('reducer', () => {
 
     expect(reducer({ roomId, username }, action)).toEqual({ roomId, username, loggedIn: false });
   });
+
+  it('handles ROOM_TOGGLE_THUMBNAIL_MODE', () => {
+    const action = {
+      type: types.ROOM_TOGGLE_THUMBNAIL_MODE,
+      payload: { thumbnailMode: true }
+    };
+
+    expect(reducer(initialState, action)).toEqual({ thumbnailMode: true });
+  });
 });
 
-it('handles ROOM_LOGIN_REQUEST', () => {
-  const action = {
-    type: types.ROOM_LOGIN_REQUEST,
-    payload: { roomId, username }
-  };
-
-  expect(reducer({ roomId, username }, action)).toEqual({ roomId, username, loggingIn: true });
-});
 
 describe('action creators', () => {
   describe.skip('#login', () => {

--- a/src/state/ducks/room.test.js
+++ b/src/state/ducks/room.test.js
@@ -25,17 +25,12 @@ describe('reducer', () => {
     const action = {
       type: types.ROOM_LOGIN
     };
-    const nextState = {
-      ...initialState,
-      roomId,
-      username: 'me'
-    };
 
     expect(reducer({ roomId, username }, action)).toEqual({
       roomId,
       username,
       loggingIn: false,
-      loggedIn: true
+      loggedIn: true,
       thumbnailMode: false,
     });
   });

--- a/src/styles/utils.css
+++ b/src/styles/utils.css
@@ -10,3 +10,13 @@
   -webkit-transform: rotateY(180deg); /* Safari and Chrome */
   -moz-transform: rotateY(180deg); /* Firefox */
 }
+
+/**
+ * Hide the video (although it is still there). Otherwise, we could*/
+/* not take the pictures.
+ */
+video.invisible {
+  position: fixed;
+  left: 0;
+  top: 0;
+}


### PR DESCRIPTION
This PR tries to bring back #308. It is still a WIP.

## TODO

- [ ] Integrate the remaining commits from #308 (configurable pictures intervals, bug fixing, etc.).
- [ ] Properly display other participants pictures (`video: true`, although it is ignored).
- [ ] Do not subscribe when a remote participant joins after the thumbnail mode has been enabled.
- [ ] Reproduce video from the speaker.
- [ ] [NTH] Try to reduce the interval to get the first picture.

## Out of Scope

- Split `Participant` into smaller components (display the video, take pictures, display image/picture...).