### PR TITLE
Do not display the small video for the main speaker

### DIFF
--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -39,7 +39,7 @@ function Participant({
   const dispatch = useDispatch();
   const videoRef = React.createRef();
   const cssClassName = `Participant ${focus === 'user' ? 'focus' : ''}`;
-  const showVideo = video || isLocalScreen;
+  const showVideo = (video || isLocalScreen) && !focus;
 
   useEffect(() => setVideo(id, videoRef.current), [id, videoRef, streamReady]);
 

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -26,6 +26,17 @@ function toggleFocus(id, focus) {
   return focus === 'user' ? participantsActions.unsetFocus() : participantsActions.setFocus(id);
 }
 
+/**
+ * @param props {object}
+ * @param props.id {}
+ * @param props.username {}
+ * @param props.isPublisher {}
+ * @param props.isLocalScreen {}
+ * @param props.streamReady {}
+ * @param props.focus {string?} null: no focus; 'auto': focus because speaking; 'user': focused by clicking
+ * @param props.speaking {}
+ * @param props.video {}
+ */
 function Participant({
   id,
   username,


### PR DESCRIPTION
When a user is the main speaker, her/his small video should be stopped (replaced by the user icon).