### PR TITLE
Do not crash if a set Fn is not defined

### DIFF
--- a/src/janus-api/models/feed.js
+++ b/src/janus-api/models/feed.js
@@ -45,7 +45,7 @@ export const createFeedFactory = (dataChannelService, eventsService) => (attrs) 
     connected: 'connected'
   };
 
-  const statusAttrs = ['name', 'speaking', 'audio', 'video', 'picture', 'connected'];
+  const statusAttrs = ['name', 'speaking', 'audio', 'video', 'picture'];
 
   /**
    * Checks if a given channel is enabled
@@ -463,7 +463,11 @@ export const createFeedFactory = (dataChannelService, eventsService) => (attrs) 
       if (!local_attr) return;
 
       const fn = 'set' + capitalize(local_attr);
-      that[fn](attrs[key]);
+      if (fn in that) {
+        that[fn](attrs[key]);
+      } else {
+        console.warn(fn, "is not defined for Feed");
+      }
     });
   };
 


### PR DESCRIPTION
Currently it is crashing because setConnected is not defined, it is not cleat that we need the setter as we have already a setConnection, therefore removing it by now and added a safe check to not crash if a setter method is not defined.