### PR TITLE
Fix Feed constructor

### DIFF
--- a/src/janus-api/models/feed.test.js
+++ b/src/janus-api/models/feed.test.js
@@ -15,6 +15,29 @@ const connection = {
 
 const createFeed = createFeedFactory(dataChannelService, eventsService);
 
+describe('#createFeed', () => {
+  it('returns a feed with the given values', () => {
+    const feed = createFeed({
+      id: 1, isLocalScreen: true, ignored: true
+    });
+    expect(feed.id).toEqual(1);
+    expect(feed.localScreen).toEqual(true);
+    expect(feed.ignored).toEqual(true);
+  });
+
+  describe('when no attributes are given', () => {
+    it('returns a feed with default values', () => {
+      const feed = createFeed({});
+      expect(feed.id).toEqual(0);
+      expect(feed.display).toBeNull();
+      expect(feed.publisher).toEqual(false);
+      expect(feed.localScreen).toEqual(false);
+      expect(feed.connection).toBeNull();
+      expect(feed.dataChannelService).toEqual(dataChannelService);
+      expect(feed.eventsService).toEqual(eventsService);
+    });
+  });
+});
 describe('#isEnabled', () => {
   describe('when is a publisher', () => {
     describe('but the connection is not defined', () => {

--- a/src/janus-api/models/feed.ts
+++ b/src/janus-api/models/feed.ts
@@ -30,8 +30,8 @@ const statusAttrs = ['name', 'speaking', 'audio', 'video', 'picture'];
  * Feed (?)
  */
 export class Feed {
-  id: number = 0;
-  display: string;
+  id: number;
+  display: string | null;
   publisher: boolean;
   localScreen: boolean;
   ignored: boolean;
@@ -48,12 +48,12 @@ export class Feed {
   constructor({
     id, display, isPublisher, isLocalScreen, connection, ignored, dataChannelService, eventsService
   }: FeedArgs) {
-    this.id = id;
-    this.display = display;
-    this.publisher = isPublisher;
-    this.localScreen = isLocalScreen;
-    this.ignored = ignored; // is still used?
-    this.connection = connection;
+    this.id = id || 0;
+    this.display = display || null;
+    this.publisher = isPublisher || false;
+    this.localScreen = isLocalScreen || false;
+    this.ignored = ignored || false; // is still used?
+    this.connection = connection || null;
     this.dataChannelService = dataChannelService;
     this.eventsService = eventsService;
   }
@@ -342,7 +342,7 @@ export class Feed {
    * Gets the current display name for publisher
    * @return {string} - current display
    */
-  getDisplay(): string {
+  getDisplay(): string | null {
     return this.display;
   };
 


### PR DESCRIPTION
Fix a problem introduced when working on #369 which caused some Feed properties to not be properly initialized. It caused incoming participants to not be shown.