### PR TITLE
Several fixes for the chat

### DIFF
--- a/src/components/Chat/Message/Message.js
+++ b/src/components/Chat/Message/Message.js
@@ -42,7 +42,7 @@ function Message({ type, index, content, text, timestamp, onRender }) {
 
   return (
     <li
-      className="rounded m-2 p-1 bg-white overflow-hidden overflow-x-auto shadow"
+      className="rounded scroll-mb-2 m-2 p-1 bg-white overflow-hidden overflow-x-auto shadow"
       data-testid="message" data-index={index}>
       <div className="px-2 italic text-xs md:text-sm">{text}</div>
     </li>

--- a/src/components/Chat/Message/Message.js
+++ b/src/components/Chat/Message/Message.js
@@ -43,7 +43,7 @@ function Message({ type, index, content, text, timestamp, onRender }) {
   return (
     <li
       className="rounded m-2 p-1 bg-white overflow-hidden overflow-x-auto shadow"
-      data-testid="message">
+      data-testid="message" data-index={index}>
       <div className="px-2 italic text-xs md:text-sm">{text}</div>
     </li>
   );

--- a/src/components/Chat/MessagesList/MessagesList.js
+++ b/src/components/Chat/MessagesList/MessagesList.js
@@ -66,6 +66,7 @@ function MessagesList() {
     const displayed = latestDisplayedMessage();
     if (displayed) {
       const idx = parseInt(displayed.dataset.index);
+      if (idx === null) { return }
       dispatch(chatActions.markDisplayed(idx));
     }
   };

--- a/src/components/Chat/MessagesList/MessagesList.js
+++ b/src/components/Chat/MessagesList/MessagesList.js
@@ -56,7 +56,9 @@ function MessagesList() {
 
     if (!lastMsg || !mustScroll(lastMsg)) return;
 
-    lastMsg.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    // This used to include {behavior: 'smooth'} but the delay introduced by it sometimes
+    // confused mustScroll in some machines/browsers
+    lastMsg.scrollIntoView({ block: 'end' });
   };
 
   /*

--- a/src/components/Chat/Toggler/Toggler.js
+++ b/src/components/Chat/Toggler/Toggler.js
@@ -36,10 +36,19 @@ function Toggler() {
 
   const { displayed, list: messages } = useSelector((state) => state.messages);
 
+  const isUnread = (message) => {
+    // We only care about chat messages, not other kind of notifications
+    if (message.type !== "chatMsg") { return false }
+    // We don't care about our own messages
+    if (message.content.feed.isPublisher) { return false }
+
+    return message.index > displayed;
+  };
+
   // Use debounce to give the new messages the opportunity to be displayed
   // (that may imply waiting for an smooth scroll to finish)
   const [unread] = useDebounce(
-    messages.filter((m) => m.type === "chatMsg" && m.index > displayed).length,
+    messages.filter((m) => isUnread(m)).length,
     300
   );
 

--- a/src/state/ducks/messages.js
+++ b/src/state/ducks/messages.js
@@ -68,7 +68,11 @@ const reducer = function(state = initialState, action) {
     case MESSAGE_DISPLAYED: {
       const index = action.payload;
 
-      return {...state, displayed: Math.max(index, state.displayed) };
+      if (index === null) {
+        return {...state};
+      } else {
+        return {...state, displayed: Math.max(index, state.displayed) };
+      }
     }
 
     default:

--- a/src/state/ducks/messages.test.js
+++ b/src/state/ducks/messages.test.js
@@ -15,7 +15,7 @@ const newMessage = { feed: '5678', text: 'See you!' };
 const newEntry = createLogEntry('chatMsg', newMessage);
 
 describe('reducer', () => {
-  const initialState = { list: [{ id: '1234', content: 'Hello!', type: 'message' }] };
+  const initialState = { displayed: -1, list: [{ id: '1234', content: 'Hello!', type: 'message' }] };
 
   it('does not handle unknown action', () => {
     const action = { type: 'UNKNOWN', payload: newMessage };
@@ -30,6 +30,18 @@ describe('reducer', () => {
       ...initialState,
       list: [...initialState.list, expect.objectContaining({text: newEntry.text(), content: newMessage})]
     });
+  });
+
+  it('handles MESSAGE_DISPLAYED with a correct index', () => {
+    const action = { type: actionTypes.MESSAGE_DISPLAYED, payload: 2 };
+
+    expect(reducer(initialState, action)).toEqual({...initialState, displayed: 2});
+  });
+
+  it('does nothing for MESSAGE_DISPLAYED with a null index', () => {
+    const action = { type: actionTypes.MESSAGE_DISPLAYED, payload: null };
+
+    expect(reducer(initialState, action)).toEqual(initialState);
   });
 });
 


### PR DESCRIPTION
First of all, this fixes the problem in the count of unread messages that was not always updated. The culprit was that sometimes an action of type `messages/DISPLAYED` was being dispatched with a payload of `null`. This is fixed at three levels:

- Added the missing `data-index` that was causing the value to be `null`. The attribute was there for regular chat messages but not for notifications like "jdoe left the room".
- Stop dispatching the action if the index is `null` (which should not happen anymore thanks to the fix above).
- If an action with `null` is received (which should never happen due to the two fixes above), do nothing.

On the other hand, this also introduces a change in behavior: messages written by the own user are never considered as unread (you wrote them, so you don't need to read them again).

Last but not least, this introduces some small adjustments on how the scrolling is displayed, to minimize the chances of the scroll been left behind due to the speed of incoming messages.