### PR TITLE
Stop tracks when disconnecting (fixes ##394)

### DIFF
--- a/src/janus-api/models/feed.ts
+++ b/src/janus-api/models/feed.ts
@@ -224,6 +224,19 @@ export class Feed {
       this.speakObserver.destroy();
     }
     this.connection = null;
+    this.removeStream();
+  };
+
+  /**
+   * Unsets the stream from the feed, stopping all its tracks.
+   */
+  private removeStream() {
+    if (this.stream) {
+      let tracks = this.stream.getTracks();
+      for(let i in tracks) {
+        tracks[i].stop();
+      }
+    }
     this.stream = null;
   };
 


### PR DESCRIPTION
When leaving the room, stop all the tracks so the browser is aware of the disconnection and turns off the physical indicators (like the camera light).

Fixes #394 