### PR TITLE
Calculate participant sizes with Javascript

### DIFF
--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -39,7 +39,8 @@ const Video = ({id, focus, streamReady, showVideo, isPublisher, isLocalScreen}) 
       autoPlay
       className={classNames(
         showVideo || 'hidden',
-        isPublisher && !isLocalScreen && 'mirrored'
+        isPublisher && !isLocalScreen && 'mirrored',
+        "max-h-full"
       )}
       onClick={() => dispatch(toggleFocus(id, focus))}
     />
@@ -74,14 +75,16 @@ function Participant({
   return (
     <div
       className={classNames(
-        'participant relative group p-1 border-2 bg-white',
+        'participant relative group bg-white',
         'transition duration-150 ease-in-out',
         focus || 'border-white',
         focus && 'border-secondary shadow-md',
         speaking && 'border-green-300'
       )}
-      style={{width: "calc(var(--partSlotWidth) - 6px", height: "calc(var(--partSlotWidth) - 6px)", margin: "3px"}}>
-      <div className="relative bg-gray-100">
+      style={{width: "calc(var(--partSlotWidth) - 6px)", margin: "3px", padding: "4px", "border-width": "2px"}}>
+      <div
+        className="relative bg-gray-100"
+        style={{"height": "calc((var(--partSlotWidth) - 18px) * 0.75)"}}>
         <ParticipantVideo 
           id={id}
           focus={focus}
@@ -94,7 +97,7 @@ function Participant({
       </div>
       <div className="flex items-center p-1 bg-gray-200">
         <ParticipantActions participantId={id} />
-        <div className="text-sx md:text-sm whitespace-no-wrap truncate">{username}</div>
+        <div className="text-sm whitespace-no-wrap truncate">{username}</div>
       </div>
     </div>
   );

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -74,12 +74,13 @@ function Participant({
   return (
     <div
       className={classNames(
-        'relative group p-1 border-2 bg-white',
+        'participant relative group p-1 border-2 bg-white',
         'transition duration-150 ease-in-out',
         focus || 'border-white',
         focus && 'border-secondary shadow-md',
         speaking && 'border-green-300'
-      )}>
+      )}
+      style={{width: "calc(var(--partSlotWidth) - 6px", height: "calc(var(--partSlotWidth) - 6px)", margin: "3px"}}>
       <div className="relative bg-gray-100">
         <ParticipantVideo 
           id={id}

--- a/src/components/Participant/ParticipantActions.js
+++ b/src/components/Participant/ParticipantActions.js
@@ -28,7 +28,7 @@ function ParticipantActions({ participantId }) {
   const visibleActionsProps = {
     ...commonProps,
     showLabel: false,
-    className: 'w-6 md:w-4 mr-1'
+    className: 'w-4 mr-1'
   };
 
   const moreActionsProps = {

--- a/src/components/Participants/Participants.js
+++ b/src/components/Participants/Participants.js
@@ -14,13 +14,8 @@ import Participant from '../Participant';
  * See setParticipantVars
  */
 function getCssConfig(element, property, def) {
-  let value = element.style.getPropertyValue(property);
-
-  if (value === "") {
-    return def;
-  } else {
-    return Number(value);
-  }
+  const value = element.style.getPropertyValue(property);
+  return value === "" ? def : Number(value);
 }
 
 /*
@@ -38,17 +33,17 @@ function getCssConfig(element, property, def) {
  * --partHeightExtra and --partWidthExtra.
  */
 function setParticipantVars(div) {
-  let totalWidth = div.offsetWidth;
-  let totalHeight = div.offsetHeight;
-  let qty = div.querySelectorAll(".participant").length;
+  const totalWidth = div.offsetWidth;
+  const totalHeight = div.offsetHeight;
+  const qty = div.querySelectorAll(".participant").length;
 
-  let max = getCssConfig(div, "--partMaxSlotWidth", 160);
-  let min = getCssConfig(div, "--partMinSlotWidth", 80);
-  let step = getCssConfig(div, "--partStepSlotWidth", 4);
+  const max = getCssConfig(div, "--partMaxSlotWidth", 160);
+  const min = getCssConfig(div, "--partMinSlotWidth", 80);
+  const step = getCssConfig(div, "--partStepSlotWidth", 4);
 
-  let heightFactor = getCssConfig(div, "--partHeightFactor", 1);
-  let heightExtra = getCssConfig(div, "--partHeightExtra", 0);
-  let widthExtra = getCssConfig(div, "--partWidthExtra", 0);
+  const heightFactor = getCssConfig(div, "--partHeightFactor", 1);
+  const heightExtra = getCssConfig(div, "--partHeightExtra", 0);
+  const widthExtra = getCssConfig(div, "--partWidthExtra", 0);
 
   let slotWidth, perRow, numRows, rowHeight;
 

--- a/src/components/Participants/Participants.js
+++ b/src/components/Participants/Participants.js
@@ -98,7 +98,8 @@ const Participants = () => {
   return (
     <div
       ref={mainRef}
-      className="h-full w-full flex flex-row flex-wrap content-start overflow-x-hidden overflow-y-auto">
+      className="h-full w-full flex flex-row flex-wrap content-start overflow-x-hidden overflow-y-auto"
+      style={{"--partWidthExtra": 18, "--partHeightExtra": 46, "--partHeightFactor": 0.75}}>
       {orderedParticipants.map((participant) => {
         let {
           id,

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -20,6 +20,13 @@ import reducers from './state/ducks';
 // in jsdom yet. Related to https://github.com/jsdom/jsdom/issues/1695
 Element.prototype.scrollTo = jest.fn();
 
+// Mock the browser's observer used to resize the participant thumbnails
+class MockObserver {
+  observe() { jest.fn() }
+  disconnect() { jest.fn() }
+}
+window.ResizeObserver = MockObserver;
+
 export function renderWithRedux(
   ui,
   { initialState, store = createStore(reducers, initialState) } = {}


### PR DESCRIPTION
In the react-redux branch we tried to calculate the size of the participants only with CSS. But the behavior is not the desired one. We wanted it to behave similar to the Angular branch, which seems impossible using pure CSS.

This pull request brings back the logic used in the Angular branch, but with a twist. Instead of setting the width and height of each participant directly with Javascript, this uses Javascript to calculate the desired width of the participants and stores the value a CSS variable. By default, the algorithm assumes a square representation of each participant, but it can be configured (using the `--partHeightFactor` CSS variable) to consider any other proportion (eg. 4:3). The algorithm can be further configured with other CSS variables like `---partMaxSlotWidth`, `--partMinSlotWidth` and `--partStepSlotWidth` to define the range of sizes and like `--partHeightExtra` and `--partWidthExtra` to fine-tune the calculation when `--partHeightFactor` is different from the default 1. 

This PR also includes some changes in the CSS that rely on the mentioned mechanism to provide a list of participants with a fixed 4:3 ratio in the videos, similar to the one in the Angular branch.

![hablando](https://user-images.githubusercontent.com/3638289/216564344-d5151957-8341-4fe4-9cbc-86fb350a611d.png)
