### PR TITLE
Redistribute the layout in big screens

### DIFF
--- a/src/components/layouts/Classic/index.js
+++ b/src/components/layouts/Classic/index.js
@@ -29,20 +29,20 @@ function Classic() {
             <ChatToggler />
           </Header>
         </div>
-        <div className="flex-1 pt-2 overflow-hidden grid gap-2 grid-rows-6 grid-cols-2 sm:grid-flow-col">
+        <div className="flex-1 pt-2 overflow-hidden grid gap-2 grid-rows-6 grid-cols-2 lg:grid-cols-3 sm:grid-flow-col">
           <Notifications
             className="w-full absolute z-50 flex flex-col items-center"
           />
           <div
             className={classNames(
-              'flex p-1 justify-center overflow-hidden row-span-2 col-span-2 sm:row-span-3 sm:col-span-1',
+              'flex p-1 justify-center overflow-hidden row-span-2 col-span-2 sm:row-span-3 sm:col-span-1 lg:col-span-2',
               !showChat && 'sm:row-span-6'
             )}>
             <Speaker />
           </div>
           <div
             className={classNames(
-              'overflow-y-auto row-span-2 col-span-2 border-t sm:row-span-3 sm:col-span-1 sm:border-t-0',
+              'overflow-y-auto row-span-2 col-span-2 border-t sm:row-span-3 sm:col-span-1 lg:col-span-2 sm:border-t-0',
               !showChat && 'row-span-4 sm:row-span-6'
             )}>
             <Participants />


### PR DESCRIPTION
I wide screens, giving half of the horizontal space to the chat looks like too much. This reduces that to only one third if the browser width is 1024px or bigger.

The first row in the table below shows the result in a browser windows => 1024px.

The second row is 1024 > browser > 640.

The third one is browser < 640px.

| With chat             |  Hidden chat |
:-------------------------:|:-------------------------:
![1](https://user-images.githubusercontent.com/3638289/216593864-e7e25223-3067-43ea-9f85-4a8db52a6d9d.png)|![4](https://user-images.githubusercontent.com/3638289/216594078-14018fc8-b8f9-4acd-932f-88e72acb58c6.png)
![2](https://user-images.githubusercontent.com/3638289/216594114-e4e696c1-f2ee-46ff-b1d8-77133d06b620.png)|![5](https://user-images.githubusercontent.com/3638289/216594161-bee6d456-013d-4875-91fd-2616ab35b16c.png)
![3](https://user-images.githubusercontent.com/3638289/216594239-4b9e888c-a034-4761-852f-885df605cd93.png)|![6](https://user-images.githubusercontent.com/3638289/216594274-dda89c32-ebee-4954-af52-ebc9fd873ba6.png)


