### PR TITLE
React UI tweaks

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -19,7 +19,7 @@ function Header({ children }) {
       <div className="flex w-1/5 py-1 justify-center">
         <Logo className="h-6 w-auto" />
       </div>
-      <div className="flex w-2/5 justify-end">
+      <div className="flex gap-1 w-2/5 justify-end">
         {/* General actions */}
         {children}
         <RoomActions className="ml-4 p-px" />

--- a/src/components/Participant/Actions/ToggleAudio.js
+++ b/src/components/Participant/Actions/ToggleAudio.js
@@ -13,7 +13,7 @@ import { classNames } from '../../../utils/common';
 
 import ParticipantActionButton from './ParticipantActionButton';
 
-function ToggleAudio({ participantId, iconStyle, ...props }) {
+function ToggleAudio({ participantId, iconStyle, activeClassNames = "", inactiveClassNames = "", ...props }) {
   const dispatch = useDispatch();
   const participant = useSelector((state) => state.participants[participantId]);
   if (!participant) return null;
@@ -33,6 +33,7 @@ function ToggleAudio({ participantId, iconStyle, ...props }) {
       disabled={disabled}
       iconStyle={classNames(
         disabled ? disableClassNames : enableClassNames,
+        audio? activeClassNames : inactiveClassNames,
         iconStyle
       )}
       onClick={() => dispatch(participantsActions.toggleAudio(participantId))}

--- a/src/components/Participant/Actions/ToggleVideo.js
+++ b/src/components/Participant/Actions/ToggleVideo.js
@@ -13,7 +13,7 @@ import { classNames } from '../../../utils/common';
 
 import ParticipantActionButton from './ParticipantActionButton';
 
-function ToggleVideo({ video, participantId, disabled, ...props }) {
+function ToggleVideo({ video, participantId, disabled, iconStyle, activeClassNames = 'text-green-600', inactiveClassNames = 'text-red-600', ...props }) {
   const dispatch = useDispatch();
   const icon = video ? Video : VideoOff;
   const label = video ? 'Switch Video Off' : 'Switch Video On';
@@ -24,8 +24,8 @@ function ToggleVideo({ video, participantId, disabled, ...props }) {
       label={label}
       disabled={disabled}
       iconStyle={classNames(
-        video ? 'text-green-600' : 'text-red-600',
-        props.iconStyle
+        iconStyle,
+        video ? activeClassNames : inactiveClassNames
       )}
       onClick={() => dispatch(participantsActions.toggleVideo())}
       {...props}

--- a/src/components/Participant/HeaderActions.js
+++ b/src/components/Participant/HeaderActions.js
@@ -20,7 +20,9 @@ function HeaderActions() {
   const actionsProps = {
     participantId: participant.id,
     showLabel: false,
-    className: 'p-0.5 rounded'
+    activeClassNames: 'bg-white text-green-600',
+    inactiveClassNames: 'bg-secondary !text-white',
+    iconStyle: 'p-0.5 rounded',
   };
 
   return [

--- a/src/components/Participant/HeaderActions.js
+++ b/src/components/Participant/HeaderActions.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) [2023] SUSE Linux
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectors } from '../../state/ducks/participants';
+import { ToggleAudio, ToggleVideo } from './Actions';
+
+function HeaderActions() {
+  const participant = useSelector((state) => selectors.localParticipant(state.participants));
+
+  if (!participant) {
+    return null;
+  }
+
+  const actionsProps = {
+    participantId: participant.id,
+    showLabel: false,
+    className: 'p-0.5 rounded'
+  };
+
+  return [
+    <ToggleAudio key="toggle-audio-header" {...actionsProps} />,
+    <ToggleVideo key="toggle-video-header" video={participant.video} {...actionsProps} />
+  ];
+}
+
+export default HeaderActions;

--- a/src/components/Participant/HeaderActions.js
+++ b/src/components/Participant/HeaderActions.js
@@ -5,7 +5,7 @@
  * of the MIT license.  See the LICENSE.txt file for details.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { selectors } from '../../state/ducks/participants';
 import { ToggleAudio, ToggleVideo } from './Actions';

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -80,7 +80,7 @@ function Participant({
         focus && 'border-secondary shadow-md',
         speaking && 'border-green-300'
       )}
-      style={{width: "calc(var(--partSlotWidth) - 6px)", margin: "3px", padding: "4px", "border-width": "2px"}}>
+      style={{width: "calc(var(--partSlotWidth) - 6px)", margin: "3px", padding: "4px", borderWidth: "2px"}}>
       <div
         className="relative bg-gray-100"
         style={{"height": "calc((var(--partSlotWidth) - 18px) * 0.75)"}}

--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -27,7 +27,6 @@ function toggleFocus(id, focus) {
 }
 
 const Video = ({id, focus, streamReady, showVideo, isPublisher, isLocalScreen}) => {
-  const dispatch = useDispatch();
   const videoRef = React.createRef();
 
   useEffect(() => setVideo(id, videoRef.current), [id, videoRef, streamReady]);
@@ -42,7 +41,6 @@ const Video = ({id, focus, streamReady, showVideo, isPublisher, isLocalScreen}) 
         isPublisher && !isLocalScreen && 'mirrored',
         "max-h-full"
       )}
-      onClick={() => dispatch(toggleFocus(id, focus))}
     />
   );
 };
@@ -71,6 +69,7 @@ function Participant({
   video
 }) {
   const showVideo = (video || isLocalScreen) && !focus;
+  const dispatch = useDispatch();
 
   return (
     <div
@@ -84,7 +83,8 @@ function Participant({
       style={{width: "calc(var(--partSlotWidth) - 6px)", margin: "3px", padding: "4px", "border-width": "2px"}}>
       <div
         className="relative bg-gray-100"
-        style={{"height": "calc((var(--partSlotWidth) - 18px) * 0.75)"}}>
+        style={{"height": "calc((var(--partSlotWidth) - 18px) * 0.75)"}}
+        onClick={() => dispatch(toggleFocus(id, focus))}>
         <ParticipantVideo 
           id={id}
           focus={focus}

--- a/src/components/layouts/Classic/index.js
+++ b/src/components/layouts/Classic/index.js
@@ -13,6 +13,7 @@ import Speaker from '../../Speaker';
 import Participants from '../../Participants';
 import Chat from '../../Chat';
 import ChatToggler from '../../Chat/Toggler';
+import ParticipantActions from '../../Participant/HeaderActions';
 import Notifications from '../../Notifications';
 
 import { classNames } from '../../../utils/common';
@@ -26,6 +27,7 @@ function Classic() {
       <div className="h-full padding-b-4 flex flex-col bg-gray-100">
         <div className="px-4 pt-2 pb-1 text-white font-bold border-b-4 border-secondary bg-primary-dark ">
           <Header>
+            <ParticipantActions />
             <ChatToggler />
           </Header>
         </div>


### PR DESCRIPTION
Two UI improvements:

- Manage the focus by clicking on the whole preview area of the participant in the roster, not necessarily in the video element. Removing the focus becomes possible again.
- Add buttons to toggle video and audio in the header. 

![Screenshot from 2023-02-03 16-08-42](https://user-images.githubusercontent.com/1691872/216651223-b9634f47-367a-492a-aaec-f80b1c7066d6.png)
