### PR TITLE
Some UI adjustments

### DIFF
--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -82,7 +82,7 @@ function Participant({
       )}
       style={{width: "calc(var(--partSlotWidth) - 6px)", margin: "3px", padding: "4px", borderWidth: "2px"}}>
       <div
-        className="relative bg-gray-100"
+        className="relative flex justify-evenly bg-primary-dark"
         style={{"height": "calc((var(--partSlotWidth) - 18px) * 0.75)"}}
         onClick={() => dispatch(toggleFocus(id, focus))}>
         <ParticipantVideo 

--- a/src/components/Participants/Participants.js
+++ b/src/components/Participants/Participants.js
@@ -93,7 +93,7 @@ const Participants = () => {
   return (
     <div
       ref={mainRef}
-      className="h-full w-full flex flex-row flex-wrap content-start overflow-x-hidden overflow-y-auto"
+      className="h-full w-full flex flex-row flex-wrap content-start justify-evenly overflow-x-hidden overflow-y-auto"
       style={{"--partWidthExtra": 18, "--partHeightExtra": 46, "--partHeightFactor": 0.75}}>
       {orderedParticipants.map((participant) => {
         let {

--- a/src/components/Participants/Participants.js
+++ b/src/components/Participants/Participants.js
@@ -93,8 +93,8 @@ const Participants = () => {
   return (
     <div
       ref={mainRef}
-      className="h-full w-full flex flex-row flex-wrap content-start justify-evenly overflow-x-hidden overflow-y-auto"
-      style={{"--partWidthExtra": 18, "--partHeightExtra": 46, "--partHeightFactor": 0.75}}>
+      className="h-full w-full grid content-start justify-evenly overflow-x-hidden overflow-y-auto"
+      style={{"--partWidthExtra": 18, "--partHeightExtra": 46, "--partHeightFactor": 0.75, "grid-template-columns": "repeat(auto-fill, var(--partSlotWidth))"}}>
       {orderedParticipants.map((participant) => {
         let {
           id,


### PR DESCRIPTION
Just a few layout improvements based on what I saw in a group meeting today.

Namely, 

* [Improve participants alignment by distributing space evenly](https://github.com/jangouts/jangouts/commit/d0a31e2c227c0ab5d17dd95852fd7d7a8433c0b1)
  
  <em>See the amount of available space at the right of participants list</em>

  | Before | After |
  |:-:|:-:|
  | ![Screenshot from 2023-02-08 12-12-30](https://user-images.githubusercontent.com/1691872/217537377-6eabafba-2383-4e67-8171-693e5083812f.png) | ![Screenshot from 2023-02-08 12-16-24](https://user-images.githubusercontent.com/1691872/217537454-312287cf-534e-4eb8-bd6b-443b7433371d.png) |

* [Better alignment of participant video](https://github.com/jangouts/jangouts/commit/2cd894738e7b026134596d30b9b588e3283b3924)

  <em>I tested that it works in both sides, x and y axis.</em>

  | Before | After |
  |:-:|:-:|
  | ![Screenshot from 2023-02-08 12-24-25](https://user-images.githubusercontent.com/1691872/217539572-37f092f9-a261-4d05-93f1-7a078d985b09.png) | ![Screenshot from 2023-02-08 12-25-50](https://user-images.githubusercontent.com/1691872/217539621-04d91042-8391-4c6e-ac98-682e19317903.png) |

* [Keep improving participants alignment](https://github.com/jangouts/jangouts/commit/6a16000778e4c7a79dee832b10440bb15ed6420e)

  <em>By changing from Flexbox to CSS Grid to avoid "weird" (for us) behavior when distributing space evenly in the last row. To know more, see https://travishorn.com/some-ways-to-align-the-last-row-in-a-flexbox-grid-720f365dcb16 for example.</em>

  | Before | After |
  |:-:|:-:|
  | ![Screenshot from 2023-02-08 12-41-29](https://user-images.githubusercontent.com/1691872/217544287-cdfa89bc-a574-470e-b320-2457fb98dc43.png) | ![Screenshot from 2023-02-08 12-41-20](https://user-images.githubusercontent.com/1691872/217544361-60b52906-c1da-4b65-9aaf-c8ff715f2f8c.png) |