### PR TITLE
Fix participant background color

### DIFF
--- a/src/components/Participant/Participant.js
+++ b/src/components/Participant/Participant.js
@@ -82,7 +82,10 @@ function Participant({
       )}
       style={{width: "calc(var(--partSlotWidth) - 6px)", margin: "3px", padding: "4px", borderWidth: "2px"}}>
       <div
-        className="relative flex justify-evenly bg-primary-dark"
+        className={classNames(
+          "relative flex justify-evenly",
+          showVideo ? "bg-primary-dark" : "bg-gray-100"
+        )}
         style={{"height": "calc((var(--partSlotWidth) - 18px) * 0.75)"}}
         onClick={() => dispatch(toggleFocus(id, focus))}>
         <ParticipantVideo 


### PR DESCRIPTION
Change made at commit https://github.com/jangouts/jangouts/pull/405/commits/2cd894738e7b026134596d30b9b588e3283b3924 as part of #405 makes the participant icon looks very ugly. So, this change is about using the dark background only when the participant is rendering a video.

|Before | After |
|-|-|
|![Screenshot 2023-02-14 at 10-20-00 Jangouts](https://user-images.githubusercontent.com/1691872/218707948-2608d119-fae3-457a-ab03-e6d35331fe4e.png) | ![Screenshot 2023-02-14 at 10-19-37 Jangouts](https://user-images.githubusercontent.com/1691872/218707963-d873487d-6e17-49ed-a6f2-bc446c8f4577.png) |


