### PR TITLE
Add backwards compatible URL to rooms

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -25,6 +25,8 @@ function App() {
           <Routes>
             <Route path="/" element={<Login />} />
             <Route path="/room/:roomId" element={<Room />} />
+            {/* Backwards compatibility with the URLs of the Angular-based version */}
+            <Route path="/rooms/:roomId" element={<Room />} />
           </Routes>
         </HashRouter>
       </AppStarter>


### PR DESCRIPTION
This addresses #414.

This approach of just having a `<Route>` for each type of URL seems to work just fine in my experiments. From the user point if view it looks just like a redirection.

In fact, I tested several approaches with `<Navigate>` and other redirection techniques but they were more complex and I didn't appreciate any advantage.