### PR TITLE
Add a "Powered by Jangouts" link

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -24,7 +24,7 @@ function Login() {
         <Logo className="w-2/3 mx-auto" />
         <LoginForm />
         <div className="text-xs text-white text-center mt-5">
-          Powered by <a target="_blank" href="https://github.com/jangouts/jangouts" className="underline">Jangouts</a>
+          Powered by <a target="_blank" rel="noreferrer" href="https://github.com/jangouts/jangouts" className="underline">Jangouts</a>
         </div>
       </div>
     </div>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -20,9 +20,12 @@ function Login() {
 
   return (
     <div className="flex items-center justify-center h-screen w-screen bg-signal">
-      <div className="w-5/6 sm:w-2/3 lg:w-1/3 p-5 lg:py-8 bg-primary-dark shadow-2xl">
+      <div className="w-5/6 sm:w-2/3 lg:w-1/3 p-5 lg:py-4 bg-primary-dark shadow-2xl">
         <Logo className="w-2/3 mx-auto" />
         <LoginForm />
+        <div className="text-xs text-white text-center mt-5">
+          Powered by <a target="_blank" href="https://github.com/jangouts/jangouts" className="underline">Jangouts</a>
+        </div>
       </div>
     </div>
   );

--- a/src/components/layouts/Classic/index.js
+++ b/src/components/layouts/Classic/index.js
@@ -56,7 +56,7 @@ function Classic() {
   };
 
   return (
-    <div className="w-screen h-screen bg-primary-dark border-b-8 border-primary-dark">
+    <div className="w-screen h-screen bg-primary-dark border-b-1 border-primary-dark">
       <div className="h-full padding-b-4 flex flex-col bg-gray-100">
         <div className="px-4 pt-2 pb-1 text-white font-bold border-b-4 border-secondary bg-primary-dark">
           <Header>
@@ -83,6 +83,9 @@ function Classic() {
             <Participants />
           </div>
           <ChatColumn />
+        </div>
+        <div className="bg-primary-dark border-t-2 border-secondary text-xs text-white text-center py-1">
+          Powered by <a target="_blank" href="https://github.com/jangouts/jangouts" className="underline">Jangouts</a>
         </div>
       </div>
     </div>

--- a/src/components/layouts/Classic/index.js
+++ b/src/components/layouts/Classic/index.js
@@ -85,7 +85,7 @@ function Classic() {
           <ChatColumn />
         </div>
         <div className="bg-primary-dark border-t-2 border-secondary text-xs text-white text-center py-1">
-          Powered by <a target="_blank" href="https://github.com/jangouts/jangouts" className="underline">Jangouts</a>
+          Powered by <a target="_blank" rel="noreferrer" href="https://github.com/jangouts/jangouts" className="underline">Jangouts</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR simply adds a tiny _Powered by [Jangouts](https://github.com/jangouts/jangouts)_ message/link in the login screen and in the footer of the layout. 

It's _hardcoded_ because it does not pay off to create a component for it at this point because we plan to make some changes in the UI for rethinking the style technique and building a few layouts more. So, it makes more sense to improve this as part of these changes.

| Login screen | Room |
|-|-|
|![Screen Shot 2023-02-16 at 23 57 20](https://user-images.githubusercontent.com/1691872/219514767-16716d02-6726-4d90-aee1-4f102f618f4d.png) | ![Screen Shot 2023-02-16 at 23 57 17](https://user-images.githubusercontent.com/1691872/219514777-1bfe3cdb-9ace-4a61-9f50-150f25ee3fb2.png) |


Fix https://github.com/jangouts/jangouts/issues/411