### PR TITLE
Polish configuration

### DIFF
--- a/public/config.json.sample
+++ b/public/config.json.sample
@@ -1,5 +1,6 @@
 {
   "janusServer": null,
+  "janusDebug": false,
   "janusWithCredentials": true,
   "joinUnmutedLimit": 3,
   "videoThumbnails": true

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -26,7 +26,7 @@ export default (function() {
   };
 
   that.setup = function(
-    { janusServer, janusServerSSL, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
+    { janusServer, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
     handler
   ) {
     that.eventsService = createEventsService();
@@ -43,7 +43,7 @@ export default (function() {
     );
 
     that.roomService = createRoomService(
-      { janusServer, janusServerSSL, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
+      { janusServer, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
       that.feedsService,
       that.dataChannelService,
       that.eventsService,

--- a/src/janus-api/index.js
+++ b/src/janus-api/index.js
@@ -26,7 +26,7 @@ export default (function() {
   };
 
   that.setup = function(
-    { janusServer, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
+    { janusServer, janusDebug, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
     handler
   ) {
     that.eventsService = createEventsService();
@@ -43,7 +43,7 @@ export default (function() {
     );
 
     that.roomService = createRoomService(
-      { janusServer, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
+      { janusServer, janusDebug, janusWithCredentials, joinUnmutedLimit, videoThumbnails },
       that.feedsService,
       that.dataChannelService,
       that.eventsService,

--- a/src/janus-api/room-service.js
+++ b/src/janus-api/room-service.js
@@ -10,49 +10,14 @@ import { createRoomFromJanus } from './models/room';
 import { createFeedConnection } from './models/feed-connection';
 
 /**
- * Returns the Janus server URL from the configuration
- *
- * @param {String} server Janus server URI
- * @param {String} sslServer Janus SSL server URI
- * @param {Boolean} useSSL Whether to use SSL or not
- */
-const configuredJanusServer = (server, sslServer, useSSL) =>
-  sslServer && useSSL ? sslServer : server;
-
-/**
- * Guess the default janus server
- *
- * @todo it is copied from the old room service. Please, refactor.
- */
-const defaultJanusServer = (useSSL) => {
-  let wsProtocol;
-  let wsPort;
-
-  if (useSSL) {
-    wsProtocol = 'wss:';
-    wsPort = '8989';
-  } else {
-    wsProtocol = 'ws:';
-    wsPort = '8188';
-  }
-
-  return [
-    wsProtocol + '//' + window.location.hostname + ':' + wsPort + '/janus/',
-    window.location.protocol + '//' + window.location.hostname + '/janus/'
-  ];
-};
-
-/**
  * Builds an object to interact with a Janus server
  *
  * @param {Object} config Janus config options
- * @property {String} config.janusServer Janus server URL
- * @property {String} config.janusServerSSL Janus SSL server URL
+ * @property {String | Array<String>} config.janusServer Janus server URL. It can be an array with several URLs.
  * @property {Boolean} config.janusDebug NOT IMPLEMENTED
- * @property {Boolean} config.janusWithCredentials Set credentials in XHR requests
+ * @property {Boolean} config.janusWithCredentials Whether to set credentials in XHR requests
  * @property {Integer} config.joinUnmutedLimit Feeds limit to connect as unmuted
- * @property {Boolean} config.videThumbnails Use only thumbnails
- * @property {Boolean} config.useSSL Whether to use SSL or not (TODO: autodetect?)
+ * @property {Boolean} config.videoThumbnails Whether to use video thumbnails by default
  * @returns {Object}
  */
 export const createRoomService = (
@@ -62,9 +27,7 @@ export const createRoomService = (
   eventsService,
   actionService
 ) => {
-  const { janusServer, janusServerSSL, janusWithCredentials, useSSL, joinUnmutedLimit } = config;
-  // TODO: the logic for default values should be encapsulated in a proper object
-  const videoThumbnails = config.videoThumbnails === undefined ? true : config.videoThumbnails;
+  const { janusServer, janusWithCredentials, joinUnmutedLimit, videoThumbnails } = config;
   const createFeedConnectionFactory = createFeedConnection(eventsService);
   let startMuted = false;
 
@@ -74,8 +37,7 @@ export const createRoomService = (
     privateId: null,
     withCredentials: !!janusWithCredentials
   };
-  that.server =
-    configuredJanusServer(janusServer, janusServerSSL, useSSL) || defaultJanusServer(useSSL);
+  that.server = janusServer;
 
   /**
    * Connects to the Janus server
@@ -383,7 +345,7 @@ export const createRoomService = (
           connection.confirmConfig();
         } else if (msg.started) {
           // Initial setConfig, needed to complete all the initializations
-          connection.setConfig({ values: { audio: true, data: true, video: videoThumbnails } });
+          connection.setConfig({ values: { audio: true, data: true, video: !!videoThumbnails } });
         } else if (msg.error_code === 428) {
           console.log("We tried to subscribe to a feed that is not publishing (an attendee)");
           actionService.stopIgnoringFeed(id);

--- a/src/janus-api/room-service.js
+++ b/src/janus-api/room-service.js
@@ -14,7 +14,7 @@ import { createFeedConnection } from './models/feed-connection';
  *
  * @param {Object} config Janus config options
  * @property {String | Array<String>} config.janusServer Janus server URL. It can be an array with several URLs.
- * @property {Boolean} config.janusDebug NOT IMPLEMENTED
+ * @property {Boolean | String | Array<String>} config.janusDebug Debug parameter for Janus.init()
  * @property {Boolean} config.janusWithCredentials Whether to set credentials in XHR requests
  * @property {Integer} config.joinUnmutedLimit Feeds limit to connect as unmuted
  * @property {Boolean} config.videoThumbnails Whether to use video thumbnails by default
@@ -27,7 +27,7 @@ export const createRoomService = (
   eventsService,
   actionService
 ) => {
-  const { janusServer, janusWithCredentials, joinUnmutedLimit, videoThumbnails } = config;
+  const { janusServer, janusDebug, janusWithCredentials, joinUnmutedLimit, videoThumbnails } = config;
   const createFeedConnectionFactory = createFeedConnection(eventsService);
   let startMuted = false;
 
@@ -49,7 +49,7 @@ export const createRoomService = (
       if (that.janus) {
         resolve(true);
       } else {
-        Janus.init();
+        Janus.init({debug: janusDebug});
         console.log(that.server);
         that.janus = new Janus({
           server: that.server,

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -15,7 +15,7 @@ const DEFAULT_CONFIG = {
 // Map protocols to ports
 const PORTS = {
   ws: '8188',
-  wss: '8189'
+  wss: '8989'
 };
 
 /**
@@ -39,7 +39,10 @@ const usingSSL = () => window.location.protocol === 'https:';
  */
 const defaultJanusServer = () => {
   const proto = usingSSL() ? 'wss' : 'ws';
-  return `${proto}://${window.location.hostname}:${PORTS[proto]}/janus`;
+  return [
+    `${proto}://${window.location.hostname}/janus`,
+    `${proto}://${window.location.hostname}:${PORTS[proto]}/janus`
+  ];
 };
 
 /**

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -47,7 +47,7 @@ const defaultJanusServer = () => {
  *
  * For the time being, only `%{hostname}` is supported.
  */
-const replacePlaceholders = (text) => text.replace('%{hostname}', window.location.hostname);
+const replacePlaceholders = (text) => text.replace(/%{hostname}/g, window.location.hostname);
 
 /**
  * Parses and builds the configuration object.

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -7,6 +7,7 @@
 
 // Values for the default configuration
 const DEFAULT_CONFIG = {
+  janusDebug: false,
   janusWithCredentials: true,
   joinUnmutedLimit: 3,
   videoThumbnails: true

--- a/src/utils/config.test.js
+++ b/src/utils/config.test.js
@@ -35,33 +35,41 @@ describe('#fetchConfig', () => {
     mockFetch({ ok: false });
 
     const config = await fetchConfig();
-    expect(config.janusServer).toEqual("ws://localhost:8188/janus");
+    expect(config.janusServer).toEqual(
+      ["ws://localhost/janus", "ws://localhost:8188/janus"]
+    );
   });
 
   it('returns the default configuration if no valid JSON is found', async () => {
     mockFetch({ ok: true, text: 'not JSON' });
 
     const config = await fetchConfig();
-    expect(config.janusServer).toEqual("ws://localhost:8188/janus");
+    expect(config.janusServer).toEqual(
+      ["ws://localhost/janus", "ws://localhost:8188/janus"]
+    );
   });
 
-  it('includes the ws: janusServer if none is given and current proto is http', async () => {
+  it('includes ws: URLs in janusServer if none is given and current proto is http', async () => {
     mockFetch({ ok: true, text: '{}' });
 
     delete window.location;
     window.location = { protocol: 'http:', hostname: 'example.net' };
 
     const config = await fetchConfig();
-    expect(config.janusServer).toEqual("ws://example.net:8188/janus");
+    expect(config.janusServer).toEqual(
+      ["ws://example.net/janus", "ws://example.net:8188/janus"]
+    );
   });
 
-  it('includes the wss: janusServer if none is given and the current proto is https', async () => {
+  it('includes wss: URLs in janusServer if none is given and the current proto is https', async () => {
     mockFetch({ ok: true, text: '{}' });
 
     delete window.location;
     window.location = { protocol: 'https:', hostname: 'example.net' };
 
     const config = await fetchConfig();
-    expect(config.janusServer).toEqual("wss://example.net:8189/janus");
+    expect(config.janusServer).toEqual(
+      ["wss://example.net/janus", "wss://example.net:8989/janus"]
+    );
   });
 });


### PR DESCRIPTION
## Problem

The configuration in the `react-redux` branch was confusing for several reasons.

1) Both the `janusAPI` and `fetchConfig` contained logic to calculate the default values of the settings, especially the URL of the Janus server. The logic was kind of equivalent but not identical.

2) For historical reasons, there were two settings called `janusServer` and `janusServerSSL`. That's confusing and unnecessary. Especially taking into account that SSL is a must anyways, since modern browsers will not open WebRTC connections unless SSL is used.

3) The setting `janusDebug` got missing in the transition from the  `master` (Angular) branch to the `react-redux` one.

4) Moreover, there was a bug. `fetchConfig` should replace the placeholder `%{hostname}` in the config file with its corresponding value. But only the first occurrence was replaced.

## Solution

Now `janusAPI` does not calculate any default value. That responsibility is delegated to the application (`fetchConfig` in our case) and `janusAPI` requires the final configuration to be given.

Adapted the logic in `fetchConfig` to have the best parts of the two previous calculations.

Removed `janusServerSSL`. Now there is only one parameter to set the URL(s) of the Janus server in all cases. Note it can be an array with several URLs to be all tried.

Bring back a functional `janusDebug` setting.

Fixed the bug in parsing the config file. Now all the occurrences of the placeholder are replaced.