### PR TITLE
Avoid React warning about css property

### DIFF
--- a/src/components/Participants/Participants.js
+++ b/src/components/Participants/Participants.js
@@ -94,7 +94,7 @@ const Participants = () => {
     <div
       ref={mainRef}
       className="h-full w-full grid content-start justify-evenly overflow-x-hidden overflow-y-auto"
-      style={{"--partWidthExtra": 18, "--partHeightExtra": 46, "--partHeightFactor": 0.75, "grid-template-columns": "repeat(auto-fill, var(--partSlotWidth))"}}>
+      style={{"--partWidthExtra": 18, "--partHeightExtra": 46, "--partHeightFactor": 0.75, "gridTemplateColumns": "repeat(auto-fill, var(--partSlotWidth))"}}>
       {orderedParticipants.map((participant) => {
         let {
           id,


### PR DESCRIPTION
This brings not visible change in the UI, but silents a warning in the javascript console.