### PR TITLE
Allow deployment in relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "Jangouts",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^18.0.0",


### PR DESCRIPTION
Before this change, every time I wanted to deploy the `react-redux` branch at _https://li2023-182.members.linode.com/beta/_ I was forced to rebuild the app specifying `homepage: "/beta"` at package.json.

After this change, that's not needed anymore. The very same build can be deployed at the root of the server or at a subdirectory and in both cases it works like a charm.

See more info at https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths

I tested it with both absolute and relative paths (that is, with the application deployed at _example.com_ and also at _example.com/something/_) and everything worked. I was able to land on the login page (with the selector of rooms), enter a room, leave the room, etc. No problem.

I detected that pressing the "back" button of the browser doesn't work as one could expect. Once you have entered the room, pushing "back" doesn't return you to the login page. But that's not a new issue introduced by this commit. It doesn't work either at the current `react-redux` branch without this change.