### PR TITLE
Handle wrong PIN

### DIFF
--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -28,6 +28,9 @@ function Room() {
     const searchParams = new URLSearchParams(location.search);
     const username = searchParams.get('user') || randomUsername();
     // TODO: get username from local storage
+
+    // Save settings, in case we don't come from the login form
+    dispatch(roomActions.saveSettings({...room.settings, username, roomId}));
     dispatch(roomActions.login(username, roomId));
   }, []);
 

--- a/src/components/Room/Room.test.js
+++ b/src/components/Room/Room.test.js
@@ -32,16 +32,24 @@ janusApi.getRooms= () => Promise.resolve([]);
 Janus.attachMediaStream = jest.fn();
 
 describe('when the user is not logged in', () => {
+  it('updates the settings with the username and room id from the URL', () => {
+    const store = mockStore({ ...initialState, room: { ...initialState.room, loggedIn: false } });
+    renderWithRedux(<Room location={{ search: '?user=Jane' }} />, { store });
+
+    expect(store.getActions()).toContainEqual({
+      type: 'jangouts/room/SETTINGS_LOAD',
+      payload: { settings: { ...initialState.room.settings, roomId: '5678', username: 'Jane' } }
+    });
+  });
+
   it('tries to log in taking room and username from the URL', () => {
     const store = mockStore({ ...initialState, room: { ...initialState.room, loggedIn: false } });
     renderWithRedux(<Room location={{ search: '?user=Jane' }} />, { store });
 
-    expect(store.getActions()).toEqual([
-      {
-        type: 'jangouts/room/LOGIN_REQUEST',
-        payload: { roomId: 5678, username: 'Jane' }
-      }
-    ]);
+    expect(store.getActions()).toContainEqual({
+      type: 'jangouts/room/LOGIN_REQUEST',
+      payload: { roomId: 5678, username: 'Jane' }
+    });
   });
 });
 

--- a/src/janus-api/room-service.js
+++ b/src/janus-api/room-service.js
@@ -51,10 +51,13 @@ export const createRoomService = (
       } else {
         Janus.init({debug: janusDebug});
         console.log(that.server);
-        that.janus = new Janus({
+        const jn = new Janus({
           server: that.server,
           withCredentials: that.withCredentials,
-          success: () => resolve(true),
+          success: () => {
+            that.janus = jn;
+            resolve(true);
+          },
           error: (e) => {
             // TODO: move this to a better place
             const msg = `Janus error: ${e}. Do you want to reload in order to retry?"`;

--- a/src/janus-api/room-service.js
+++ b/src/janus-api/room-service.js
@@ -128,13 +128,12 @@ export const createRoomService = (
   that.enter = (username, pin) => {
     return new Promise((resolve, reject) => {
       that.connect().then(function() {
-        that.doEnter(username, pin);
-        resolve();
+        that.doEnter(username, pin, resolve, reject);
       });
     });
   };
 
-  that.doEnter = (username, pin) => {
+  that.doEnter = (username, pin, resolve, reject) => {
     let connection = null;
     that.pin = pin;
 
@@ -192,6 +191,7 @@ export const createRoomService = (
         // Step 2. Response from janus confirming we joined
         if (event === 'joined') {
           console.log('Successfully joined room ' + msg.room);
+          resolve(true);
           // sending user joined event
           eventsService.auditEvent('user');
 
@@ -251,7 +251,8 @@ export const createRoomService = (
           }
           // The server reported an error
           if (isPresent(msg.error)) {
-            console.log('Error message from server' + msg.error);
+            console.log('Error message from server', msg.error);
+            reject(msg.error);
             eventsService.roomEvent('reportError', { error: msg.error });
           }
         }

--- a/src/state/ducks/room.js
+++ b/src/state/ducks/room.js
@@ -84,7 +84,7 @@ const initialSettings = () => {
   return settings;
 };
 
-export const initialState = { settings: initialSettings().toPlain(), loggedIn: false, loggingIn: false };
+export const initialState = { settings: initialSettings().toPlain(), loggedIn: false, loggingIn: false, error: null };
 
 const reducer = function(state = initialState, action) {
   const { type, payload } = action;
@@ -97,7 +97,7 @@ const reducer = function(state = initialState, action) {
       if (payload !== undefined && payload.error) {
         return { ...state, loggingIn: false, loggedIn: false, error: payload.error };
       } else {
-        return { ...state, loggingIn: false, loggedIn: true };
+        return { ...state, loggingIn: false, loggedIn: true, error: null };
       }
     }
     case ROOM_SETTINGS_LOAD: {

--- a/src/state/ducks/room.test.js
+++ b/src/state/ducks/room.test.js
@@ -29,7 +29,8 @@ describe('reducer', () => {
       roomId,
       username,
       loggingIn: false,
-      loggedIn: true
+      loggedIn: true,
+      error: null
     });
   });
 


### PR DESCRIPTION
Mitigates #413 

Currently deployed at https://li2023-182.members.linode.com/beta/

The React part was somehow prepared to handle a login error (see #427 for more details about that "somehow"), but the `janusApi` always resolved the `enterRoom` promise, no matter whether the operation succeeded or not. With this patch, it rejects the promise in case of error.

In addition, this includes fixes to the React part to cleanup previous errors when a new login succeeds and to memoize the username and the room id if the user skips the login form.

The pull request also includes a fix for a race condition that caused some queries to `janusAPI` to fail. It became especially visible when entering directly the URL of a room with pin (it now redirects back to the login form and the query to populate the list of rooms failed there due to the race condition).

This is probably all the best we can do without tackling #427 (apart from the redirection flickering caused by that, it works as expected in all situations).